### PR TITLE
Fix UI error where category is not cleared for the next one

### DIFF
--- a/app/src/androidTest/java/com/escodro/alkaa/framework/Events.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/framework/Events.kt
@@ -45,6 +45,10 @@ class Events {
         onView(withText(resId)).perform(click())
     }
 
+    fun clickOnViewWithText(text: String) {
+        onView(withText(text)).perform(click())
+    }
+
     fun clickOnRecyclerItem(@IdRes recyclerView: Int) {
         onView(withId(recyclerView)).perform(
             RecyclerViewActions

--- a/app/src/androidTest/java/com/escodro/alkaa/ui/TaskFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/ui/TaskFlowTest.kt
@@ -210,6 +210,16 @@ class TaskFlowTest : AcceptanceTest<MainActivity>(MainActivity::class.java) {
         checkThat.viewIsCompletelyDisplayed(R.id.btn_taskdetail_date)
     }
 
+    @Test
+    fun checkIfSecondTaskHasCleanCategory() {
+        val title = "Thanks a lot for your help. :)"
+        addAndOpenTask("I really want this... Help me?")
+        events.clickOnChild(R.id.chipgrp_taskdetail_category, 0)
+        events.navigateUp()
+        addAndOpenTask(title)
+        checkThat.viewIsNotChecked(R.id.chipgrp_taskdetail_category, 0)
+    }
+
     private fun addTask(taskName: String) {
         events.clickOnView(R.id.edittext_itemadd_description)
         events.textOnView(R.id.edittext_itemadd_description, taskName)
@@ -220,7 +230,7 @@ class TaskFlowTest : AcceptanceTest<MainActivity>(MainActivity::class.java) {
 
     private fun addAndOpenTask(taskName: String) {
         addTask(taskName)
-        events.clickOnRecyclerItem(R.id.recyclerview_tasklist_list)
+        events.clickOnViewWithText(taskName)
         checkThat.viewHasText(R.id.edittext_taskdetail_title, taskName)
         checkThat.viewHasText(R.id.toolbar_title, "")
     }

--- a/app/src/main/java/com/escodro/alkaa/ui/task/detail/TaskDetailProvider.kt
+++ b/app/src/main/java/com/escodro/alkaa/ui/task/detail/TaskDetailProvider.kt
@@ -1,7 +1,9 @@
 package com.escodro.alkaa.ui.task.detail
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.escodro.alkaa.common.extension.applySchedulers
+import com.escodro.alkaa.common.extension.notify
 import com.escodro.alkaa.data.local.model.Task
 import com.escodro.alkaa.di.provider.DaoProvider
 import io.reactivex.Observable
@@ -13,7 +15,10 @@ import timber.log.Timber
  */
 class TaskDetailProvider(daoProvider: DaoProvider) {
 
-    val taskData = MutableLiveData<Task>()
+    val taskData: LiveData<Task>
+        get() = mutableTaskData
+
+    private var mutableTaskData = MutableLiveData<Task>()
 
     private val taskDao = daoProvider.getTaskDao()
 
@@ -34,7 +39,7 @@ class TaskDetailProvider(daoProvider: DaoProvider) {
             .applySchedulers().subscribe(
                 {
                     Timber.d("loadTask = ${it.title}")
-                    taskData.value = it
+                    mutableTaskData.value = it
                 },
                 { Timber.e("Task not found in database") })
 
@@ -53,6 +58,7 @@ class TaskDetailProvider(daoProvider: DaoProvider) {
             .applySchedulers()
             .subscribe()
 
+        mutableTaskData.notify()
         compositeDisposable.add(disposable)
     }
 
@@ -61,6 +67,7 @@ class TaskDetailProvider(daoProvider: DaoProvider) {
      */
     fun clear() {
         Timber.d("clear()")
+        mutableTaskData = MutableLiveData()
         compositeDisposable.clear()
     }
 }

--- a/app/src/main/java/com/escodro/alkaa/ui/task/detail/alarm/TaskAlarmViewModel.kt
+++ b/app/src/main/java/com/escodro/alkaa/ui/task/detail/alarm/TaskAlarmViewModel.kt
@@ -2,7 +2,6 @@ package com.escodro.alkaa.ui.task.detail.alarm
 
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
-import com.escodro.alkaa.common.extension.notify
 import com.escodro.alkaa.ui.task.alarm.notification.TaskNotificationScheduler
 import com.escodro.alkaa.ui.task.detail.TaskDetailProvider
 import timber.log.Timber
@@ -37,7 +36,6 @@ class TaskAlarmViewModel(
             taskProvider.updateTask(it)
             alarmManager.scheduleTaskAlarm(it)
         }
-        taskData.notify()
     }
 
     /**
@@ -51,6 +49,5 @@ class TaskAlarmViewModel(
             alarmManager.cancelTaskAlarm(it.id)
             taskProvider.updateTask(it)
         }
-        taskData.notify()
     }
 }


### PR DESCRIPTION
Once the LiveData was not being cleared after each interaction, if the new value was "null" for category (which happens when creating a new one every time), the LiveData would load the previous one. This impacts only the UI, the data remains with no category.