### PR TITLE
:recycle: Remove hardcoded constants to control Task List state

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/di/Modules.kt
+++ b/app/src/main/java/com/escodro/alkaa/di/Modules.kt
@@ -34,7 +34,7 @@ val applicationModule = module {
     viewModel { MainTaskViewModel() }
 
     // Task
-    single { TaskListContract(get(), get()) }
+    single { TaskListContract(get()) }
     viewModel { TaskListViewModel(get()) }
 
     // Task Detail

--- a/app/src/main/java/com/escodro/alkaa/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/escodro/alkaa/ui/main/MainActivity.kt
@@ -18,8 +18,8 @@ import com.escodro.alkaa.common.extension.hideKeyboard
 import com.escodro.alkaa.common.extension.isOpen
 import com.escodro.alkaa.common.extension.navigateSingleTop
 import com.escodro.alkaa.data.local.model.Category
-import com.escodro.alkaa.ui.task.list.TaskListContract
 import com.escodro.alkaa.ui.task.list.TaskListFragment
+import com.escodro.alkaa.ui.task.list.TaskListState
 import kotlinx.android.synthetic.main.activity_main.*
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
@@ -141,8 +141,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun navigateToCategory(item: MenuItem) {
+        val state = when (item.itemId) {
+            ALL_TASKS_ITEM -> TaskListState.ShowAllTasks
+            COMPLETED_ITEM -> TaskListState.ShowCompletedTasks
+            else -> TaskListState.ShowTaskByCategory(item.itemId.toLong())
+        }
+
         val bundle = bundleOf(
-            TaskListFragment.EXTRA_CATEGORY_ID to item.itemId.toLong(),
+            TaskListFragment.EXTRA_TASK_LIST_STATE to state,
             TaskListFragment.EXTRA_CATEGORY_NAME to item.title
         )
         navController.navigateSingleTop(R.id.taskListFragment, bundle)
@@ -179,11 +185,15 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
 
-        private const val ALL_TASKS_ITEM = TaskListContract.ALL_TASKS.toInt()
+        // Drawer Menu Constants
 
-        private const val COMPLETED_ITEM = TaskListContract.COMPLETED_TASKS.toInt()
+        private const val ALL_TASKS_ITEM = 0
+
+        private const val COMPLETED_ITEM = -1
 
         private const val CATEGORY_ITEM = -2
+
+        // Drawer Menu Groups
 
         private const val GROUP_TASKS = 1
 

--- a/app/src/main/java/com/escodro/alkaa/ui/task/list/TaskListFragment.kt
+++ b/app/src/main/java/com/escodro/alkaa/ui/task/list/TaskListFragment.kt
@@ -37,8 +37,6 @@ class TaskListFragment : Fragment() {
 
     private var navigator: NavController? = null
 
-    private var itemId: Long = 0
-
     private val adapter = TaskListAdapter(
         onItemClicked = ::onItemClicked,
         onItemLongPressed = ::onItemLongPressed,
@@ -92,11 +90,13 @@ class TaskListFragment : Fragment() {
     private fun loadTasks() {
         Timber.d("loadTasks()")
 
+        val state = arguments?.getParcelable<TaskListState>(TaskListFragment.EXTRA_TASK_LIST_STATE)
+            ?: TaskListState.ShowAllTasks
+
         val defaultTitle = getString(R.string.drawer_menu_all_tasks)
-        itemId = arguments?.getLong(TaskListFragment.EXTRA_CATEGORY_ID) ?: 0
         val taskName = arguments?.getString(TaskListFragment.EXTRA_CATEGORY_NAME) ?: defaultTitle
 
-        viewModel.loadTasks(itemId, onTasksLoaded = { onTaskLoaded(it) })
+        viewModel.loadTasks(state, onTasksLoaded = ::onTaskLoaded)
         sharedViewModel.updateTitle(taskName)
     }
 
@@ -108,10 +108,9 @@ class TaskListFragment : Fragment() {
         withDelay(INSERT_DELAY) { viewModel.addTask(description) }
     }
 
-    private fun onTaskLoaded(list: List<TaskWithCategory>) {
+    private fun onTaskLoaded(list: List<TaskWithCategory>, showAddButton: Boolean) {
         Timber.d("onTaskLoaded() - Size = ${list.size}")
 
-        val showAddButton = itemId != TaskListContract.COMPLETED_TASKS
         adapter.updateList(list, showAddButton)
 
         if (list.isEmpty() && !showAddButton) {
@@ -170,8 +169,8 @@ class TaskListFragment : Fragment() {
 
         private const val INSERT_DELAY = 200L
 
-        const val EXTRA_CATEGORY_ID = "category_id"
-
         const val EXTRA_CATEGORY_NAME = "category_name"
+
+        const val EXTRA_TASK_LIST_STATE = "task_list_state"
     }
 }

--- a/app/src/main/java/com/escodro/alkaa/ui/task/list/TaskListState.kt
+++ b/app/src/main/java/com/escodro/alkaa/ui/task/list/TaskListState.kt
@@ -1,0 +1,30 @@
+package com.escodro.alkaa.ui.task.list
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * Represents the possible [TaskListFragment] states.
+ */
+sealed class TaskListState : Parcelable {
+
+    /**
+     * State to show all the tasks.
+     */
+    @Parcelize
+    object ShowAllTasks : TaskListState()
+
+    /**
+     * State to show all the completed tasks.
+     */
+    @Parcelize
+    object ShowCompletedTasks : TaskListState()
+
+    /**
+     * State to show all tasks with the specific category id.
+     *
+     * @param categoryId the category id to show only tasks related to this category
+     */
+    @Parcelize
+    data class ShowTaskByCategory(val categoryId: Long) : TaskListState()
+}


### PR DESCRIPTION
Task List state was being controlled by hardcoded constants that
were passed from Contract until reach the Activity.
The code is now refactored to use sealed classes to share the current
state between the Activity and the logic part. The contract methods
that were overload are now separated for each action.