### PR TITLE
:bug: Default categories are not being added

### DIFF
--- a/data/local/src/main/java/com/escodro/local/provider/DatabaseProvider.kt
+++ b/data/local/src/main/java/com/escodro/local/provider/DatabaseProvider.kt
@@ -37,7 +37,7 @@ class DatabaseProvider(private val context: Context) {
             override fun onCreate(db: SupportSQLiteDatabase) {
                 super.onCreate(db)
                 Executors.newSingleThreadExecutor().execute {
-                    database?.categoryDao()?.insertCategory(getDefaultCategoryList())
+                    database?.categoryDao()?.insertCategory(getDefaultCategoryList())?.subscribe()
                 }
             }
         }


### PR DESCRIPTION
[root-cause] Once all the DAO methods are now observables, it is
needed to call `subscribe` when using it

[solution] Call `subscribe` on Database Provider