### PR TITLE
Fix app crash when adding a task in a deleted category

### DIFF
--- a/app/src/androidTest/java/com/escodro/alkaa/ui/TaskCategoryTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/ui/TaskCategoryTest.kt
@@ -1,0 +1,69 @@
+package com.escodro.alkaa.ui
+
+import com.escodro.alkaa.R
+import com.escodro.alkaa.framework.AcceptanceTest
+import com.escodro.alkaa.ui.main.MainActivity
+import com.escodro.model.Category
+import org.junit.After
+import org.junit.Test
+
+/**
+ * Test class to validate the Task and Category screens flow.
+ */
+class TaskCategoryTest : AcceptanceTest<MainActivity>(MainActivity::class.java) {
+
+    @After
+    fun cleanTable() {
+        daoProvider.getTaskDao().cleanTable().blockingGet()
+        daoProvider.getCategoryDao().cleanTable().blockingGet()
+    }
+
+    @Test
+    fun addTaskAfterRemovingCategoryAndReturningToScreen() {
+        val categoryName = "Temporary"
+        val taskName = "Should be deleted together"
+        val category = Category(name = categoryName, color = "#dd55ff")
+        daoProvider.getCategoryDao().insertCategory(category).blockingAwait()
+        navigateToCategory(categoryName)
+        addTask(taskName)
+        navigateToCategoryScreen()
+        removeCategory(categoryName)
+        events.navigateUp()
+        checkThat.listNotContainsItem(R.id.recyclerview_tasklist_list, taskName)
+        checkThat.viewHasText(R.id.toolbar_title, R.string.task_list_default_title)
+        addTask("This is a new task in a new list")
+    }
+
+    private fun addTask(taskName: String) {
+        events.clickOnView(R.id.edittext_itemadd_description)
+        events.textOnView(R.id.edittext_itemadd_description, taskName)
+        events.pressImeActionButton(R.id.edittext_itemadd_description)
+        events.waitFor(1000)
+        checkThat.listContainsItem(R.id.recyclerview_tasklist_list, taskName)
+    }
+
+    private fun removeCategory(categoryName: String) {
+        events.clickOnView(R.id.imageview_itemcategory_options)
+        events.clickOnViewWithText(R.string.category_list_menu_remove)
+        events.clickOnViewWithText(R.string.category_list_dialog_remove_positive)
+        checkThat.listNotContainsItem(R.id.recyclerview_categorylist_list, categoryName)
+        checkThat.viewIsCompletelyDisplayed(R.id.textview_categorylist_empty)
+    }
+
+    private fun openDrawer() {
+        events.openDrawer(R.id.drawer_layout_main_parent)
+        checkThat.drawerIsOpen(R.id.drawer_layout_main_parent)
+    }
+
+    private fun navigateToCategoryScreen() {
+        openDrawer()
+        events.clickOnViewWithText(R.string.drawer_menu_manage_categories)
+        checkThat.viewHasText(R.id.toolbar_title, R.string.category_list_label)
+    }
+
+    private fun navigateToCategory(categoryName: String) {
+        openDrawer()
+        events.clickOnViewWithText(categoryName)
+        checkThat.viewHasText(R.id.toolbar_title, categoryName)
+    }
+}

--- a/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
+++ b/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
@@ -14,8 +14,8 @@ import com.escodro.domain.usecase.task.GetFutureTasks
 import com.escodro.domain.usecase.task.GetTask
 import com.escodro.domain.usecase.task.SnoozeTask
 import com.escodro.domain.usecase.task.UpdateTask
-import com.escodro.domain.usecase.taskwithcategory.GetTaskByCategoryId
 import com.escodro.domain.usecase.taskwithcategory.LoadCompletedTasks
+import com.escodro.domain.usecase.taskwithcategory.LoadTasksByCategory
 import com.escodro.domain.usecase.taskwithcategory.LoadUncompletedTasks
 import org.koin.dsl.module
 
@@ -36,7 +36,7 @@ val domainModule = module {
     single { LoadCategory(get(), get()) }
     single { SaveCategory(get(), get()) }
 
-    single { GetTaskByCategoryId(get(), get()) }
+    single { LoadTasksByCategory(get(), get()) }
     single { LoadCompletedTasks(get(), get()) }
     single { LoadUncompletedTasks(get(), get()) }
 

--- a/data/domain/src/main/java/com/escodro/domain/usecase/taskwithcategory/LoadTasksByCategory.kt
+++ b/data/domain/src/main/java/com/escodro/domain/usecase/taskwithcategory/LoadTasksByCategory.kt
@@ -9,21 +9,26 @@ import io.reactivex.Flowable
 /**
  * Use case to get a task with category by the category id from the database.
  */
-class GetTaskByCategoryId(
+class LoadTasksByCategory(
     private val daoProvider: DaoProvider,
     private val mapper: TaskWithCategoryMapper
 ) {
 
     /**
-     * Gets a task with category by the category id.
+     * Gets a task with category by the category id if the category exists.
      *
      * @param categoryId the category id
      *
      * @return observable to be subscribe
      */
     operator fun invoke(categoryId: Long): Flowable<List<ViewData.TaskWithCategory>> =
+        daoProvider.getCategoryDao()
+            .findCategory(categoryId)
+            .flatMapPublisher { getAllTasksWithCategoryId(it.id) }
+            .applySchedulers()
+
+    private fun getAllTasksWithCategoryId(categoryId: Long) =
         daoProvider.getTaskWithCategoryDao()
             .getAllTasksWithCategoryId(categoryId)
-            .map { mapper.toViewTask(it) }
-            .applySchedulers()
+            .map { category -> mapper.toViewTask(category) }
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskListFragment.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskListFragment.kt
@@ -96,7 +96,7 @@ class TaskListFragment : Fragment() {
         val defaultTitle = getString(R.string.task_list_default_title)
         val taskName = arguments?.getString(EXTRA_CATEGORY_NAME) ?: defaultTitle
 
-        viewModel.loadTasks(state, onTasksLoaded = ::onTaskLoaded)
+        viewModel.loadTasks(state, onTasksLoaded = ::onTaskLoaded, onLoadError = ::onLoadError)
         sharedViewModel.updateTitle(taskName)
     }
 
@@ -120,6 +120,11 @@ class TaskListFragment : Fragment() {
             recyclerview_tasklist_list?.visibility = View.VISIBLE
             textview_tasklist_empty?.visibility = View.INVISIBLE
         }
+    }
+
+    private fun onLoadError() {
+        arguments?.clear()
+        loadTasks()
     }
 
     private fun onItemClicked(taskWithCategory: ViewData.TaskWithCategory) {


### PR DESCRIPTION
[root-cause] If the list is showing the tasks under category, the user
removes the category and returns to the screen, the app crashes trying
to insert a task with an invalid foreign key.

[solution] When opening the list by category, first of all, checks if
the category is in the database. If not, the list is reloaded showing
all the uncompleted tasks.