### PR TITLE
:bug: Update Navigation crash

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -20,7 +20,7 @@ object Versions {
     const val ktx = "1.0.2"
     const val lifecycle = "1.0.0"
     const val room = "2.1.0"
-    const val navigation = "2.1.0-alpha05"
+    const val navigation = "2.1.0"
     const val playCore = "1.6.1"
 
     const val timber = "4.7.1"

--- a/features/category/src/main/java/com/escodro/category/presentation/detail/CategoryDetailFragment.kt
+++ b/features/category/src/main/java/com/escodro/category/presentation/detail/CategoryDetailFragment.kt
@@ -62,8 +62,12 @@ internal class CategoryDetailFragment : Fragment() {
     private fun initComponents() {
         Timber.d("initComponents()")
 
-        val categoryId = arguments?.let { CategoryDetailFragmentArgs.fromBundle(it).categoryId }
-        categoryId?.let { viewModel.loadCategory(it, ::updateSelectedColor) }
+        val categoryId =
+            arguments?.let { CategoryDetailFragmentArgs.fromBundle(it).categoryId } ?: 0L
+
+        if (categoryId != 0L) {
+            viewModel.loadCategory(categoryId, ::updateSelectedColor)
+        }
 
         setupTextInput()
         categoryColor = getCategoryColor()

--- a/libraries/navigation/src/main/res/navigation/nav_graph_category.xml
+++ b/libraries/navigation/src/main/res/navigation/nav_graph_category.xml
@@ -29,7 +29,8 @@
 
         <argument
             android:name="categoryId"
-            app:argType="long" />
+            app:argType="long"
+            android:defaultValue="0L"/>
 
     </fragment>
 


### PR DESCRIPTION
[root-cause] After Google update on Jetpack Navigation, it is not
possible to pass null value via Safe Args. That's on you, Google. :(

[solution] Set the default value as "0L" and handle it as adding a new
category