### PR TITLE
Fix processDebugAndroidTestResources issue

### DIFF
--- a/features/tracker/build.gradle
+++ b/features/tracker/build.gradle
@@ -1,6 +1,9 @@
 apply from: "$rootDir/config/dependencies/dynamic_dependencies.gradle"
 
 dependencies {
+    implementation project(":app")
+    androidTestImplementation project(":app")
+
     implementation project(":libraries:core")
     implementation project(":data:domain")
 


### PR DESCRIPTION
[root-cause] When running Instrumented Tests, the issue to link Android
resources related to WorkManager failed.

[solution] Adding missing dependencies from Dynamic Module to
Application module to correctly link all resources