### PR TITLE
Refactor communication between Alarm and Task

### DIFF
--- a/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
+++ b/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
@@ -1,6 +1,8 @@
 package com.escodro.domain.di
 
 import com.escodro.domain.calendar.TaskCalendar
+import com.escodro.domain.usecase.alarm.CancelAlarm
+import com.escodro.domain.usecase.alarm.ScheduleAlarm
 import com.escodro.domain.usecase.category.DeleteCategory
 import com.escodro.domain.usecase.category.LoadAllCategories
 import com.escodro.domain.usecase.category.LoadCategory
@@ -24,6 +26,8 @@ import org.koin.dsl.module
  * Domain dependency injection module.
  */
 val domainModule = module {
+
+    // Task Use Cases
     factory { AddTask(get()) }
     factory { CompleteTask(get(), get()) }
     factory { UncompleteTask(get()) }
@@ -34,16 +38,24 @@ val domainModule = module {
     factory { SnoozeTask(get()) }
     factory { UpdateTask(get()) }
 
+    // Category Use Cases
     factory { DeleteCategory(get()) }
     factory { LoadAllCategories(get()) }
     factory { LoadCategory(get()) }
     factory { UpsertCategory(get()) }
 
+    // Task With Category Use Cases
     factory { LoadTasksByCategory(get(), get()) }
     factory { LoadCompletedTasks(get()) }
     factory { LoadUncompletedTasks(get()) }
 
+    // Alarm Use Cases
+    factory { ScheduleAlarm(get()) }
+    factory { CancelAlarm(get()) }
+
+    // Tracker Use Cases
     factory { LoadCompletedTasksByPeriod(get()) }
 
+    // Providers
     factory { TaskCalendar() }
 }

--- a/data/domain/src/main/java/com/escodro/domain/interactor/AlarmInteractor.kt
+++ b/data/domain/src/main/java/com/escodro/domain/interactor/AlarmInteractor.kt
@@ -1,0 +1,22 @@
+package com.escodro.domain.interactor
+
+/**
+ * Contract to interact with the Alarm layer.
+ */
+interface AlarmInteractor {
+
+    /**
+     * Schedules a new alarm.
+     *
+     * @param alarmId the alarm id
+     * @param timeInMillis the time to the alarm be scheduled
+     */
+    fun schedule(alarmId: Long, timeInMillis: Long?)
+
+    /**
+     * Cancels an alarm.
+     *
+     * @param alarmId the alarm id
+     */
+    fun cancel(alarmId: Long)
+}

--- a/data/domain/src/main/java/com/escodro/domain/usecase/alarm/CancelAlarm.kt
+++ b/data/domain/src/main/java/com/escodro/domain/usecase/alarm/CancelAlarm.kt
@@ -1,0 +1,17 @@
+package com.escodro.domain.usecase.alarm
+
+import com.escodro.domain.interactor.AlarmInteractor
+
+/**
+ * Use case to cancel an alarm.
+ */
+class CancelAlarm(private val alarmInteractor: AlarmInteractor) {
+
+    /**
+     * Cancels an alarm.
+     *
+     * @param alarmId the alarm id
+     */
+    operator fun invoke(alarmId: Long) =
+        alarmInteractor.cancel(alarmId)
+}

--- a/data/domain/src/main/java/com/escodro/domain/usecase/alarm/ScheduleAlarm.kt
+++ b/data/domain/src/main/java/com/escodro/domain/usecase/alarm/ScheduleAlarm.kt
@@ -1,0 +1,18 @@
+package com.escodro.domain.usecase.alarm
+
+import com.escodro.domain.interactor.AlarmInteractor
+
+/**
+ * Use case to schedule a new alarm.
+ */
+class ScheduleAlarm(private val alarmInteractor: AlarmInteractor) {
+
+    /**
+     * Schedules a new alarm.
+     *
+     * @param alarmId the alarm id
+     * @param timeInMillis the time to the alarm be scheduled
+     */
+    operator fun invoke(alarmId: Long, timeInMillis: Long?) =
+        alarmInteractor.schedule(alarmId, timeInMillis)
+}

--- a/data/domain/src/test/java/com/escodro/domain/usecase/alarm/CancelAlarmTest.kt
+++ b/data/domain/src/test/java/com/escodro/domain/usecase/alarm/CancelAlarmTest.kt
@@ -1,0 +1,21 @@
+package com.escodro.domain.usecase.alarm
+
+import com.escodro.domain.interactor.AlarmInteractor
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class CancelAlarmTest {
+
+    private val mockInteractor = mockk<AlarmInteractor>(relaxed = true)
+
+    private val cancelAlarm = CancelAlarm(mockInteractor)
+
+    @Test
+    fun `check if interactor function was called`() {
+        val alarmId = 123L
+
+        cancelAlarm(alarmId)
+        verify { mockInteractor.cancel(alarmId) }
+    }
+}

--- a/data/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleAlarmTest.kt
+++ b/data/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleAlarmTest.kt
@@ -1,0 +1,23 @@
+package com.escodro.domain.usecase.alarm
+
+import com.escodro.domain.interactor.AlarmInteractor
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Calendar
+import org.junit.Test
+
+class ScheduleAlarmTest {
+
+    private val mockInteractor = mockk<AlarmInteractor>(relaxed = true)
+
+    private val scheduleAlarm = ScheduleAlarm(mockInteractor)
+
+    @Test
+    fun `check if interactor function was called`() {
+        val alarmId = 123L
+        val time = Calendar.getInstance().timeInMillis
+
+        scheduleAlarm(alarmId, time)
+        verify { mockInteractor.schedule(alarmId, time) }
+    }
+}

--- a/features/alarm/src/main/java/com/escodro/alarm/di/AlarmModule.kt
+++ b/features/alarm/src/main/java/com/escodro/alarm/di/AlarmModule.kt
@@ -1,9 +1,11 @@
 package com.escodro.alarm.di
 
+import com.escodro.alarm.interactor.AlarmInteractorImpl
 import com.escodro.alarm.mapper.TaskMapper
 import com.escodro.alarm.notification.TaskNotification
 import com.escodro.alarm.notification.TaskNotificationChannel
 import com.escodro.alarm.notification.TaskNotificationScheduler
+import com.escodro.domain.interactor.AlarmInteractor
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -17,4 +19,6 @@ val alarmModule = module {
     factory { TaskNotification(androidContext(), get()) }
 
     factory { TaskMapper() }
+
+    factory<AlarmInteractor> { AlarmInteractorImpl(get()) }
 }

--- a/features/alarm/src/main/java/com/escodro/alarm/interactor/AlarmInteractorImpl.kt
+++ b/features/alarm/src/main/java/com/escodro/alarm/interactor/AlarmInteractorImpl.kt
@@ -1,0 +1,19 @@
+package com.escodro.alarm.interactor
+
+import com.escodro.alarm.notification.TaskNotificationScheduler
+import com.escodro.domain.interactor.AlarmInteractor
+import timber.log.Timber
+
+internal class AlarmInteractorImpl(private val alarmManager: TaskNotificationScheduler) :
+    AlarmInteractor {
+
+    override fun schedule(alarmId: Long, timeInMillis: Long?) {
+        Timber.d("schedule - alarmId = $alarmId")
+        alarmManager.scheduleTaskAlarm(alarmId, timeInMillis)
+    }
+
+    override fun cancel(alarmId: Long) {
+        Timber.d("cancel - alarmId = $alarmId")
+        alarmManager.cancelTaskAlarm(alarmId)
+    }
+}

--- a/features/alarm/src/main/java/com/escodro/alarm/notification/TaskNotificationScheduler.kt
+++ b/features/alarm/src/main/java/com/escodro/alarm/notification/TaskNotificationScheduler.kt
@@ -9,9 +9,9 @@ import com.escodro.core.extension.setAlarm
 import timber.log.Timber
 
 /**
- * Alarm manager to schedule a event based on the due date from a [ViewData.Task].
+ * Alarm manager to schedule a event based on the due date from a Task.
  */
-class TaskNotificationScheduler(private val context: Context) {
+internal class TaskNotificationScheduler(private val context: Context) {
 
     /**
      * Schedules a task notification based on the due date.

--- a/features/task/build.gradle
+++ b/features/task/build.gradle
@@ -14,7 +14,6 @@ android {
 dependencies {
     implementation project(":libraries:core")
     implementation project(":libraries:navigation")
-    implementation project(":features:alarm")
     implementation project(":data:domain")
 
     implementation Deps.android.appCompat

--- a/features/task/src/main/java/com/escodro/task/di/TaskModule.kt
+++ b/features/task/src/main/java/com/escodro/task/di/TaskModule.kt
@@ -21,7 +21,7 @@ val taskModule = module {
     viewModel { TaskListViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { TaskDetailViewModel(get()) }
     viewModel { TaskCategoryViewModel(get(), get(), get()) }
-    viewModel { TaskAlarmViewModel(get(), get()) }
+    viewModel { TaskAlarmViewModel(get(), get(), get()) }
 
     // Mappers
     factory { TaskMapper() }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
@@ -3,7 +3,8 @@ package com.escodro.task.presentation.detail.alarm
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.escodro.alarm.notification.TaskNotificationScheduler
+import com.escodro.domain.usecase.alarm.CancelAlarm
+import com.escodro.domain.usecase.alarm.ScheduleAlarm
 import com.escodro.task.presentation.detail.TaskDetailProvider
 import java.util.Calendar
 import timber.log.Timber
@@ -12,8 +13,9 @@ import timber.log.Timber
  * [ViewModel] responsible to provide information to Task Alarm layout.
  */
 internal class TaskAlarmViewModel(
-    private val alarmManager: TaskNotificationScheduler,
-    private val taskProvider: TaskDetailProvider
+    private val taskProvider: TaskDetailProvider,
+    private val scheduleAlarmUseCase: ScheduleAlarm,
+    private val cancelAlarmUseCase: CancelAlarm
 ) : ViewModel() {
 
     val taskData = taskProvider.taskData
@@ -34,7 +36,7 @@ internal class TaskAlarmViewModel(
 
         taskData.value?.copy(dueDate = alarm)?.let {
             taskProvider.updateTask(it, viewModelScope)
-            alarmManager.scheduleTaskAlarm(it.id, it.dueDate?.time?.time)
+            scheduleAlarmUseCase(it.id, it.dueDate?.time?.time)
         }
     }
 
@@ -45,7 +47,7 @@ internal class TaskAlarmViewModel(
         Timber.d("removeAlarm()")
 
         taskData.value?.copy(dueDate = null)?.let {
-            alarmManager.cancelTaskAlarm(it.id)
+            cancelAlarmUseCase(it.id)
             taskProvider.updateTask(it, viewModelScope)
         }
     }


### PR DESCRIPTION
The relation between Alarm and Task were direct. Update the code to create a Use Case for Alarm usage and communicate with Task through interactor, inverting the dependency flow between than to Domain.