### PR TITLE
Missed repeating tasks are not working after reboot

### DIFF
--- a/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
+++ b/data/domain/src/main/java/com/escodro/domain/di/DomainModule.kt
@@ -52,7 +52,7 @@ val domainModule = module {
 
     // Alarm Use Cases
     factory { CancelAlarm(get(), get()) }
-    factory { RescheduleFutureAlarms(get(), get(), get()) }
+    factory { RescheduleFutureAlarms(get(), get(), get(), get()) }
     factory { ScheduleAlarm(get(), get()) }
     factory { ScheduleNextAlarm(get(), get(), get()) }
     factory { ShowAlarm(get(), get(), get()) }

--- a/data/domain/src/test/java/com/escodro/domain/usecase/alarm/RescheduleFutureAlarmsTest.kt
+++ b/data/domain/src/test/java/com/escodro/domain/usecase/alarm/RescheduleFutureAlarmsTest.kt
@@ -6,6 +6,7 @@ import com.escodro.domain.model.Task
 import com.escodro.domain.provider.CalendarProvider
 import com.escodro.domain.repository.TaskRepository
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -22,8 +23,10 @@ class RescheduleFutureAlarmsTest {
 
     private val mockCalendar = mockk<CalendarProvider>(relaxed = true)
 
+    private val mockNextAlarm = mockk<ScheduleNextAlarm>(relaxed = true)
+
     private val rescheduleFutureAlarms =
-        RescheduleFutureAlarms(mockRepo, mockAlarmInteractor, mockCalendar)
+        RescheduleFutureAlarms(mockRepo, mockAlarmInteractor, mockCalendar, mockNextAlarm)
 
     @Before
     fun setup() {
@@ -108,7 +111,7 @@ class RescheduleFutureAlarmsTest {
 
         coEvery { mockRepo.findAllTasksWithDueDate() } returns listOf(task)
         rescheduleFutureAlarms()
-        verify { mockAlarmInteractor.schedule(task.id, any()) }
+        coVerify { mockNextAlarm(task) }
     }
 
     @Test
@@ -125,6 +128,6 @@ class RescheduleFutureAlarmsTest {
 
         coEvery { mockRepo.findAllTasksWithDueDate() } returns listOf(task)
         rescheduleFutureAlarms()
-        verify(exactly = 0) { mockAlarmInteractor.schedule(task.id, any()) }
+        coVerify(exactly = 0) { mockNextAlarm(task) }
     }
 }


### PR DESCRIPTION
[root-cause] The use case was only trying to schedule the alarm for the
time the task was missed. Alarms in the past are not scheduled and is
not the expected behavior.

[solution] Add a separate logic to handle the missed repeating alarms.
Now if the alarm was a missed repeating, it calls the use case to ensure
that this alarm will be scheduled in the future.