### PR TITLE
:bug: List is always refreshing all items when updated

### DIFF
--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskAddItem.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskAddItem.kt
@@ -4,6 +4,7 @@ import com.escodro.core.extension.onActionDone
 import com.escodro.task.R
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
 import com.xwray.groupie.kotlinandroidextensions.Item
+import java.util.Objects
 import kotlinx.android.synthetic.main.item_add_task.view.*
 
 /**
@@ -22,4 +23,13 @@ internal class TaskAddItem(
     }
 
     override fun getLayout(): Int = R.layout.item_add_task
+
+    override fun getId(): Long = 0L
+
+    override fun equals(other: Any?): Boolean {
+        val otherItem = other as? TaskAddItem ?: return super.equals(other)
+        return otherItem.id == id
+    }
+
+    override fun hashCode(): Int = Objects.hashCode(id)
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskItem.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskItem.kt
@@ -10,6 +10,7 @@ import com.escodro.task.model.TaskWithCategory
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
 import com.xwray.groupie.kotlinandroidextensions.Item
 import java.util.Calendar
+import java.util.Objects
 import kotlinx.android.synthetic.main.item_task.view.*
 
 /**
@@ -63,6 +64,15 @@ internal class TaskItem(
         } else {
             View.GONE
         }
+
+    override fun getId(): Long = data.task.id
+
+    override fun equals(other: Any?): Boolean {
+        val otherItem = other as? TaskItem ?: return super.equals(other)
+        return otherItem.data == data
+    }
+
+    override fun hashCode(): Int = Objects.hashCode(data)
 
     private fun getRelativeDate(context: Context, calendar: Calendar?): String =
         context.formatRelativeDate(calendar?.timeInMillis)


### PR DESCRIPTION
[root-cause] Every new interaction that updates the list makes it blink
and refresh all the items.

[solution] When updating the code to use Groupie, I forgot to implement
the "getId()" and "equals()" functions, which makes the diff between the
items. As soon as it is implemented, it starts working properly.