### PR TITLE
Refactor after Composable discussions.

### DIFF
--- a/features/search/src/main/java/com/escodro/search/presentation/Search.kt
+++ b/features/search/src/main/java/com/escodro/search/presentation/Search.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.ExitToApp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.savedinstancestate.savedInstanceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,7 +57,7 @@ private fun SearchLoader(
     viewModel: SearchViewModel = getViewModel()
 ) {
     val (query, setQuery) = savedInstanceState { "" }
-    val viewState by viewModel.findTasksByName(query)
+    val viewState by remember(viewModel, query) { viewModel.findTasksByName(query) }
         .collectAsState(initial = SearchViewState.Empty)
 
     SearchScaffold(

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/TaskDetailActions.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/TaskDetailActions.kt
@@ -2,13 +2,12 @@ package com.escodro.task.presentation.detail
 
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.main.CategoryId
-import com.escodro.task.presentation.detail.main.TaskId
 import java.util.Calendar
 
 internal data class TaskDetailActions(
     val onTitleChanged: (String) -> Unit = {},
     val onDescriptionChanged: (String) -> Unit = {},
-    val onCategoryChanged: (TaskId, CategoryId) -> Unit = { _, _ -> },
+    val onCategoryChanged: (CategoryId) -> Unit = {},
     val onAlarmUpdated: (Calendar?) -> Unit = {},
     val onIntervalSelected: (AlarmInterval) -> Unit = {}
 )

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
@@ -7,6 +7,7 @@ import com.escodro.domain.usecase.alarm.ScheduleAlarm
 import com.escodro.domain.usecase.alarm.UpdateTaskAsRepeating
 import com.escodro.task.mapper.AlarmIntervalMapper
 import com.escodro.task.model.AlarmInterval
+import com.escodro.task.presentation.detail.main.TaskId
 import kotlinx.coroutines.launch
 import java.util.Calendar
 
@@ -17,16 +18,16 @@ internal class TaskAlarmViewModel(
     private val alarmIntervalMapper: AlarmIntervalMapper
 ) : ViewModel() {
 
-    fun updateAlarm(taskId: Long, alarm: Calendar?) = viewModelScope.launch {
+    fun updateAlarm(taskId: TaskId, alarm: Calendar?) = viewModelScope.launch {
         if (alarm != null) {
-            scheduleAlarmUseCase(taskId, alarm)
+            scheduleAlarmUseCase(taskId.value, alarm)
         } else {
-            cancelAlarmUseCase(taskId)
+            cancelAlarmUseCase(taskId.value)
         }
     }
 
-    fun setRepeating(taskId: Long, alarmInterval: AlarmInterval) = viewModelScope.launch {
+    fun setRepeating(taskId: TaskId, alarmInterval: AlarmInterval) = viewModelScope.launch {
         val interval = alarmIntervalMapper.toDomain(alarmInterval)
-        updateTaskAsRepeatingUseCase(taskId, interval)
+        updateTaskAsRepeatingUseCase(taskId.value, interval)
     }
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/category/TaskCategoryViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/category/TaskCategoryViewModel.kt
@@ -1,8 +1,5 @@
 package com.escodro.task.presentation.detail.category
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.escodro.domain.usecase.category.LoadAllCategories
@@ -10,6 +7,8 @@ import com.escodro.domain.usecase.task.UpdateTaskCategory
 import com.escodro.task.mapper.CategoryMapper
 import com.escodro.task.presentation.detail.main.CategoryId
 import com.escodro.task.presentation.detail.main.TaskId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
 internal class TaskCategoryViewModel(
@@ -18,27 +17,18 @@ internal class TaskCategoryViewModel(
     private val categoryMapper: CategoryMapper
 ) : ViewModel() {
 
-    private val _state: MutableState<TaskCategoryState> = mutableStateOf(TaskCategoryState.Empty)
-
-    val state: State<TaskCategoryState>
-        get() = _state
-
-    fun loadCategories() = viewModelScope.launch {
+    fun loadCategories(): Flow<TaskCategoryState> = flow {
         val categoryList = loadAllCategories()
 
         if (categoryList.isNotEmpty()) {
             val mappedList = categoryMapper.toView(categoryList)
-            _state.value = TaskCategoryState.Loaded(mappedList)
+            emit(TaskCategoryState.Loaded(mappedList))
         } else {
-            _state.value = TaskCategoryState.Empty
+            emit(TaskCategoryState.Empty)
         }
     }
 
     fun updateCategory(taskId: TaskId, categoryId: CategoryId) = viewModelScope.launch {
-        _state.value.run {
-            if (this is TaskCategoryState.Loaded) {
-                updateTaskCategory(taskId = taskId.value, categoryId = categoryId.value)
-            }
-        }
+        updateTaskCategory(taskId = taskId.value, categoryId = categoryId.value)
     }
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
@@ -49,11 +49,12 @@ private fun TaskDetailLoader(
     alarmViewModel: TaskAlarmViewModel = getViewModel()
 ) {
     val id = TaskId(taskId)
-    val detailViewState by detailViewModel
-        .loadTaskInfo(taskId = id)
+    val detailViewState by
+    remember(detailViewModel, taskId) { detailViewModel.loadTaskInfo(taskId = id) }
         .collectAsState(initial = TaskDetailState.Error)
 
-    val categoryViewState by categoryViewModel.loadCategories()
+    val categoryViewState by
+    remember(categoryViewModel, taskId) { categoryViewModel.loadCategories() }
         .collectAsState(initial = TaskCategoryState.Empty)
 
     val taskDetailActions = TaskDetailActions(

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
@@ -50,7 +50,7 @@ private fun TaskDetailLoader(
 ) {
     val id = TaskId(taskId)
     val detailViewState by detailViewModel
-        .setTaskInfo(taskId = id)
+        .loadTaskInfo(taskId = id)
         .collectAsState(initial = TaskDetailState.Error)
 
     val categoryViewState by categoryViewModel.loadCategories()

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
@@ -53,8 +53,8 @@ private fun TaskDetailLoader(
         .setTaskInfo(taskId = id)
         .collectAsState(initial = TaskDetailState.Error)
 
-    categoryViewModel.loadCategories()
-    val categoryViewState by categoryViewModel.state
+    val categoryViewState by categoryViewModel.loadCategories()
+        .collectAsState(initial = TaskCategoryState.Empty)
 
     val taskDetailActions = TaskDetailActions(
         onTitleChanged = { title -> detailViewModel.updateTitle(id, title) },

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetailViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetailViewModel.kt
@@ -19,7 +19,7 @@ internal class TaskDetailViewModel(
 
     private val coroutineDebouncer = CoroutineDebouncer()
 
-    fun setTaskInfo(taskId: TaskId): Flow<TaskDetailState> = flow {
+    fun loadTaskInfo(taskId: TaskId): Flow<TaskDetailState> = flow {
         val task = loadTaskUseCase(taskId = taskId.value)
 
         if (task != null) {

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -43,7 +43,7 @@ private fun TaskListLoader(
     onItemClicked: (Long) -> Unit,
     viewModel: TaskListViewModel = getViewModel()
 ) {
-    val viewState by viewModel.state.collectAsState(initial = TaskListViewState.Empty)
+    val viewState by viewModel.loadTaskList().collectAsState(initial = TaskListViewState.Empty)
 
     TaskListScaffold(
         viewState = viewState,

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -43,8 +43,7 @@ private fun TaskListLoader(
     onItemClicked: (Long) -> Unit,
     viewModel: TaskListViewModel = getViewModel()
 ) {
-    viewModel.loadTasks()
-    val viewState by viewModel.state.collectAsState()
+    val viewState by viewModel.state.collectAsState(initial = TaskListViewState.Empty)
 
     TaskListScaffold(
         viewState = viewState,

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,7 +44,8 @@ private fun TaskListLoader(
     onItemClicked: (Long) -> Unit,
     viewModel: TaskListViewModel = getViewModel()
 ) {
-    val viewState by viewModel.loadTaskList().collectAsState(initial = TaskListViewState.Empty)
+    val viewState by remember(viewModel) { viewModel.loadTaskList() }
+        .collectAsState(initial = TaskListViewState.Empty)
 
     TaskListScaffold(
         viewState = viewState,

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskListViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskListViewModel.kt
@@ -23,7 +23,7 @@ internal class TaskListViewModel(
     private val taskWithCategoryMapper: TaskWithCategoryMapper
 ) : ViewModel() {
 
-    val state: Flow<TaskListViewState> = flow {
+    fun loadTaskList(): Flow<TaskListViewState> = flow {
         loadAllTasksUseCase()
             .map { task -> taskWithCategoryMapper.toView(task) }
             .catch { error -> emit(TaskListViewState.Error(error)) }

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
@@ -3,6 +3,7 @@ package com.escodro.task.presentation.detail
 import com.escodro.task.mapper.AlarmIntervalMapper
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.alarm.TaskAlarmViewModel
+import com.escodro.task.presentation.detail.main.TaskId
 import com.escodro.task.presentation.fake.CancelAlarmFake
 import com.escodro.task.presentation.fake.ScheduleAlarmFake
 import com.escodro.task.presentation.fake.UpdateTaskAsRepeatingFake
@@ -36,7 +37,7 @@ internal class TaskAlarmViewModelTest {
         val alarm = Calendar.getInstance()
 
         // When the function to set the alarm is called
-        viewModel.updateAlarm(taskId, alarm)
+        viewModel.updateAlarm(TaskId(taskId), alarm)
 
         // Then the alarm is set
         Assert.assertTrue(scheduleAlarm.isAlarmScheduled(taskId))
@@ -50,7 +51,7 @@ internal class TaskAlarmViewModelTest {
         val alarmInterval = AlarmInterval.WEEKLY
 
         // When the function to set the alarm interval is called
-        viewModel.setRepeating(taskId, alarmInterval)
+        viewModel.setRepeating(TaskId(taskId), alarmInterval)
 
         // Then the alarm interval is set
         Assert.assertTrue(updateTaskAsRepeating.isAlarmUpdated(taskId))
@@ -64,7 +65,7 @@ internal class TaskAlarmViewModelTest {
         val taskId = 123L
 
         // When the function to cancel the alarm is called
-        viewModel.updateAlarm(taskId, null)
+        viewModel.updateAlarm(TaskId(taskId), null)
 
         // Then the alarm is removed
         Assert.assertTrue(cancelAlarm.isAlarmCancelled(taskId))

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskCategoryViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskCategoryViewModelTest.kt
@@ -9,11 +9,14 @@ import com.escodro.task.presentation.fake.FAKE_DOMAIN_CATEGORY_LIST
 import com.escodro.task.presentation.fake.LoadAllCategoriesFake
 import com.escodro.task.presentation.fake.UpdateTaskCategoryFake
 import com.escodro.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class TaskCategoryViewModelTest {
 
     @get:Rule
@@ -34,10 +37,10 @@ internal class TaskCategoryViewModelTest {
 
             // Given the viewModel is called to load the categories
             loadAllCategories.categoriesToBeReturned = FAKE_DOMAIN_CATEGORY_LIST
-            viewModel.loadCategories()
+            val flow = viewModel.loadCategories()
 
             // When the latest event is collected
-            val state = viewModel.state.value
+            val state = flow.first()
 
             // Then the category list is returned
             require(state is TaskCategoryState.Loaded)
@@ -50,10 +53,10 @@ internal class TaskCategoryViewModelTest {
         runBlockingTest {
             // Given the viewModel is called to load the categories
             loadAllCategories.categoriesToBeReturned = listOf()
-            viewModel.loadCategories()
+            val flow = viewModel.loadCategories()
 
             // When the latest event is collected
-            val state = viewModel.state.value
+            val state = flow.first()
 
             require(state is TaskCategoryState.Empty)
         }

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
@@ -4,12 +4,15 @@ import com.escodro.task.mapper.AlarmIntervalMapper
 import com.escodro.task.mapper.TaskMapper
 import com.escodro.task.presentation.detail.main.TaskDetailState
 import com.escodro.task.presentation.detail.main.TaskDetailViewModel
+import com.escodro.task.presentation.detail.main.TaskId
 import com.escodro.task.presentation.fake.FAKE_DOMAIN_TASK
 import com.escodro.task.presentation.fake.LoadTaskFake
 import com.escodro.task.presentation.fake.UpdateTaskDescriptionFake
 import com.escodro.task.presentation.fake.UpdateTaskTitleFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -36,13 +39,13 @@ internal class TaskDetailViewModelTest {
     )
 
     @Test
-    fun `test if when a task exist it returns the success state`() {
+    fun `test if when a task exist it returns the success state`() = runBlockingTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        viewModel.setTaskInfo(FAKE_DOMAIN_TASK.id)
+        val flow = viewModel.setTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
 
         // When the latest event is collected
-        val state = viewModel.state.value
+        val state = flow.first()
 
         // Then the state contain the loaded task
         require(state is TaskDetailState.Loaded)
@@ -51,13 +54,13 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when a task does not exist it returns the error state`() {
+    fun `test if when a task does not exist it returns the error state`() = runBlockingTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = null
-        viewModel.setTaskInfo(FAKE_DOMAIN_TASK.id)
+        val flow = viewModel.setTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
 
         // When the latest event is collected
-        val state = viewModel.state.value
+        val state = flow.first()
 
         // Then the state contain the loaded task
         Assert.assertTrue(state is TaskDetailState.Error)
@@ -67,12 +70,13 @@ internal class TaskDetailViewModelTest {
     fun `test if when the update title is called, the field is updated`() {
 
         // Given the viewModel is called to load the task info
+        val taskId = TaskId(FAKE_DOMAIN_TASK.id)
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        viewModel.setTaskInfo(FAKE_DOMAIN_TASK.id)
+        viewModel.setTaskInfo(taskId)
 
         // When the title is updated
         val newTitle = "title"
-        viewModel.updateTitle(title = newTitle)
+        viewModel.updateTitle(taskId = taskId, title = newTitle)
         coroutineTestRule.testDispatcher.advanceUntilIdle() /* Advance typing debounce */
 
         // Then the task will be updated with given title
@@ -85,12 +89,13 @@ internal class TaskDetailViewModelTest {
     fun `test if when the update description is called, the field is updated`() {
 
         // Given the viewModel is called to load the task info
+        val taskId = TaskId(FAKE_DOMAIN_TASK.id)
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        viewModel.setTaskInfo(FAKE_DOMAIN_TASK.id)
+        viewModel.setTaskInfo(taskId)
 
         // When the description is updated
         val newDescription = "description"
-        viewModel.updateDescription(description = newDescription)
+        viewModel.updateDescription(taskId = taskId, description = newDescription)
         coroutineTestRule.testDispatcher.advanceUntilIdle() /* Advance typing debounce */
 
         // Then the task will be updated with given description

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
@@ -42,7 +42,7 @@ internal class TaskDetailViewModelTest {
     fun `test if when a task exist it returns the success state`() = runBlockingTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        val flow = viewModel.setTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
+        val flow = viewModel.loadTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
 
         // When the latest event is collected
         val state = flow.first()
@@ -57,7 +57,7 @@ internal class TaskDetailViewModelTest {
     fun `test if when a task does not exist it returns the error state`() = runBlockingTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = null
-        val flow = viewModel.setTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
+        val flow = viewModel.loadTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
 
         // When the latest event is collected
         val state = flow.first()
@@ -72,7 +72,7 @@ internal class TaskDetailViewModelTest {
         // Given the viewModel is called to load the task info
         val taskId = TaskId(FAKE_DOMAIN_TASK.id)
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        viewModel.setTaskInfo(taskId)
+        viewModel.loadTaskInfo(taskId)
 
         // When the title is updated
         val newTitle = "title"
@@ -91,7 +91,7 @@ internal class TaskDetailViewModelTest {
         // Given the viewModel is called to load the task info
         val taskId = TaskId(FAKE_DOMAIN_TASK.id)
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-        viewModel.setTaskInfo(taskId)
+        viewModel.loadTaskInfo(taskId)
 
         // When the description is updated
         val newDescription = "description"

--- a/features/task/src/test/java/com/escodro/task/presentation/fake/LoadUncompletedTasksFake.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/fake/LoadUncompletedTasksFake.kt
@@ -5,15 +5,18 @@ import com.escodro.domain.model.Task
 import com.escodro.domain.model.TaskWithCategory
 import com.escodro.domain.usecase.taskwithcategory.LoadUncompletedTasks
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import java.util.Calendar
 
 internal class LoadUncompletedTasksFake : LoadUncompletedTasks {
 
-    var list: List<TaskWithCategory> = listOf()
+    private var list: List<TaskWithCategory> = listOf()
 
     var throwError: Boolean = false
+
+    var multipleEmissions: Boolean = false
 
     fun returnDefaultValues() {
         val task1 = Task(title = "Buy milk", dueDate = null)
@@ -49,10 +52,16 @@ internal class LoadUncompletedTasksFake : LoadUncompletedTasks {
     }
 
     override fun invoke(): Flow<List<TaskWithCategory>> {
-        return if (throwError.not()) {
-            flowOf(list)
-        } else {
-            flowOf(list).map { throw IllegalStateException() }
+        return when {
+            multipleEmissions -> multipleEmissions()
+            throwError.not() -> flowOf(list)
+            else -> flowOf(list).map { throw IllegalStateException() }
         }
     }
+
+    private fun multipleEmissions() =
+        flow {
+            emit(listOf<TaskWithCategory>())
+            emit(list)
+        }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
@@ -7,16 +7,21 @@ import com.escodro.task.mapper.TaskWithCategoryMapper
 import com.escodro.task.presentation.fake.FAKE_VIEW_TASK_WITH_CATEGORY
 import com.escodro.task.presentation.fake.LoadUncompletedTasksFake
 import com.escodro.task.presentation.fake.UpdateTaskStatusFake
+import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class TaskListViewModelTest {
+
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
 
     private val loadUncompletedTasks = LoadUncompletedTasksFake()
 
@@ -39,75 +44,62 @@ internal class TaskListViewModelTest {
         // Given the use case returns the list with uncompleted tasks
         val numberOfEntries = 14
         loadUncompletedTasks.returnValues(numberOfEntries)
-        viewModel.loadTasks()
+        val flow = viewModel.state
 
         // When the latest event is collected
-        val result = arrayListOf<TaskListViewState>()
-        val job = launch { viewModel.state.toList(result) }
+        val state = flow.first()
 
         // Then that state contains the list with uncompleted tasks
-        val state = result.first()
         require(state is TaskListViewState.Loaded)
         Assert.assertEquals(numberOfEntries, state.items.size)
-
-        job.cancel()
     }
 
     @Test
     fun `test if when there are no uncompleted items, a empty list is returned`() =
-        runBlockingTest {
+        coroutinesRule.testDispatcher.runBlockingTest {
 
             // Given the use case returns an empty list
             loadUncompletedTasks.clean()
-            viewModel.loadTasks()
+            val flow = viewModel.state
 
             // When the latest event is collected
-            val result = arrayListOf<TaskListViewState>()
-            val job = launch { viewModel.state.toList(result) }
+            val state = flow.first()
 
             // Then that state contains the empty list
-            Assert.assertTrue(result.first() is TaskListViewState.Empty)
-
-            job.cancel()
+            Assert.assertTrue(state is TaskListViewState.Empty)
         }
 
     @Test
-    fun `test if when list changes, the state is re-triggered`() = runBlockingTest {
+    fun `test if when list changes, the state is re-triggered`() =
+        coroutinesRule.testDispatcher.runBlockingTest {
 
-        // Given collecting multiple states
-        val result = arrayListOf<TaskListViewState>()
-        val job = launch { viewModel.state.toList(result) }
+            // When multiple states are sent
+            loadUncompletedTasks.returnDefaultValues()
+            loadUncompletedTasks.multipleEmissions = true
 
-        // When multiple states are sent
-        loadUncompletedTasks.clean()
-        viewModel.loadTasks()
-        loadUncompletedTasks.returnDefaultValues()
-        viewModel.loadTasks() /* Simulate the re-trigger by flow */
+            // Given collecting multiple states
+            val result = viewModel.state.toList()
 
-        // Then multiple states are collected
-        Assert.assertTrue(result.size == 2)
-        Assert.assertTrue(result[0] is TaskListViewState.Empty)
-        Assert.assertTrue(result[1] is TaskListViewState.Loaded)
-
-        job.cancel()
-    }
+            // Then multiple states are collected
+            Assert.assertEquals(2, result.size)
+            Assert.assertTrue(result[0] is TaskListViewState.Empty)
+            Assert.assertTrue(result[1] is TaskListViewState.Loaded)
+        }
 
     @Test
-    fun `test if when load tasks fails, the error state is returned`() = runBlockingTest {
+    fun `test if when load tasks fails, the error state is returned`() =
+        coroutinesRule.testDispatcher.runBlockingTest {
 
-        // Given the use case returns error
-        loadUncompletedTasks.throwError = true
-        viewModel.loadTasks()
+            // Given the use case returns error
+            loadUncompletedTasks.throwError = true
+            val flow = viewModel.state
 
-        // When the latest event is collected
-        val result = arrayListOf<TaskListViewState>()
-        val job = launch { viewModel.state.toList(result) }
+            // When the latest event is collected
+            val state = flow.first()
 
-        // Then that state contains the empty list
-        Assert.assertTrue(result.first() is TaskListViewState.Error)
-
-        job.cancel()
-    }
+            // Then that state contains the empty list
+            Assert.assertTrue(state is TaskListViewState.Error)
+        }
 
     @Test
     fun `test if task is updated`() {

--- a/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
@@ -44,7 +44,7 @@ internal class TaskListViewModelTest {
         // Given the use case returns the list with uncompleted tasks
         val numberOfEntries = 14
         loadUncompletedTasks.returnValues(numberOfEntries)
-        val flow = viewModel.state
+        val flow = viewModel.loadTaskList()
 
         // When the latest event is collected
         val state = flow.first()
@@ -60,7 +60,7 @@ internal class TaskListViewModelTest {
 
             // Given the use case returns an empty list
             loadUncompletedTasks.clean()
-            val flow = viewModel.state
+            val flow = viewModel.loadTaskList()
 
             // When the latest event is collected
             val state = flow.first()
@@ -78,7 +78,7 @@ internal class TaskListViewModelTest {
             loadUncompletedTasks.multipleEmissions = true
 
             // Given collecting multiple states
-            val result = viewModel.state.toList()
+            val result = viewModel.loadTaskList().toList()
 
             // Then multiple states are collected
             Assert.assertEquals(2, result.size)
@@ -92,7 +92,7 @@ internal class TaskListViewModelTest {
 
             // Given the use case returns error
             loadUncompletedTasks.throwError = true
-            val flow = viewModel.state
+            val flow = viewModel.loadTaskList()
 
             // When the latest event is collected
             val state = flow.first()


### PR DESCRIPTION
After a great discussion in kotlinlang Slack, some refactor were made to update the _hot flows_ to _cold flows_, giving more lifecycle control and avoiding multiple recompositions in different screens.

Special thanks to @adamp.