### PR TITLE
🐞 Search item title is now showing the complete text

### DIFF
--- a/features/search/src/main/java/com/escodro/search/presentation/Search.kt
+++ b/features/search/src/main/java/com/escodro/search/presentation/Search.kt
@@ -165,7 +165,8 @@ private fun SearchItem(task: TaskSearchItem, onItemClicked: (Long) -> Unit) {
                 textDecoration = textDecoration,
                 modifier = Modifier
                     .padding(horizontal = 12.dp)
-                    .size(24.dp)
+                    .fillMaxWidth()
+                    .height(24.dp)
             )
         }
     }


### PR DESCRIPTION
[root-cause] Instead of setting the height to a fix value, the size was
set.

[solution] Set only the height to fix size and add width to fill parent.