### PR TITLE
🐞 Default categories does not shown up in first usage

### DIFF
--- a/data/domain/src/main/java/com/escodro/domain/repository/CategoryRepository.kt
+++ b/data/domain/src/main/java/com/escodro/domain/repository/CategoryRepository.kt
@@ -1,6 +1,7 @@
 package com.escodro.domain.repository
 
 import com.escodro.domain.model.Category
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Interface to represent the implementation of Category repository.
@@ -45,7 +46,7 @@ interface CategoryRepository {
      *
      * @return all inserted categories.
      */
-    suspend fun findAllCategories(): List<Category>
+    fun findAllCategories(): Flow<List<Category>>
 
     /**
      * Gets a specific category by id.

--- a/data/domain/src/main/java/com/escodro/domain/usecase/category/LoadAllCategories.kt
+++ b/data/domain/src/main/java/com/escodro/domain/usecase/category/LoadAllCategories.kt
@@ -1,6 +1,7 @@
 package com.escodro.domain.usecase.category
 
 import com.escodro.domain.model.Category
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Use case to load all categories from the database.
@@ -11,5 +12,5 @@ interface LoadAllCategories {
      *
      * @return a mutable list of all categories
      */
-    suspend operator fun invoke(): List<Category>
+    operator fun invoke(): Flow<List<Category>>
 }

--- a/data/domain/src/main/java/com/escodro/domain/usecase/category/implementation/LoadAllCategoriesImpl.kt
+++ b/data/domain/src/main/java/com/escodro/domain/usecase/category/implementation/LoadAllCategoriesImpl.kt
@@ -3,11 +3,12 @@ package com.escodro.domain.usecase.category.implementation
 import com.escodro.domain.model.Category
 import com.escodro.domain.repository.CategoryRepository
 import com.escodro.domain.usecase.category.LoadAllCategories
+import kotlinx.coroutines.flow.Flow
 
 internal class LoadAllCategoriesImpl(
     private val categoryRepository: CategoryRepository
 ) : LoadAllCategories {
 
-    override suspend operator fun invoke(): List<Category> =
+    override operator fun invoke(): Flow<List<Category>> =
         categoryRepository.findAllCategories()
 }

--- a/data/domain/src/test/java/com/escodro/domain/usecase/category/AddCategoryTest.kt
+++ b/data/domain/src/test/java/com/escodro/domain/usecase/category/AddCategoryTest.kt
@@ -4,6 +4,7 @@ import com.escodro.domain.model.Category
 import com.escodro.domain.usecase.category.implementation.LoadAllCategoriesImpl
 import com.escodro.domain.usecase.fake.CategoryRepositoryFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Before
@@ -52,7 +53,7 @@ internal class AddCategoryTest {
             assertList.add(category)
         }
 
-        val resultList = loadAllCategoriesUseCase()
+        val resultList = loadAllCategoriesUseCase().first()
 
         Assert.assertArrayEquals(assertList.toTypedArray(), resultList.toTypedArray())
     }

--- a/data/domain/src/test/java/com/escodro/domain/usecase/fake/CategoryRepositoryFake.kt
+++ b/data/domain/src/test/java/com/escodro/domain/usecase/fake/CategoryRepositoryFake.kt
@@ -2,6 +2,8 @@ package com.escodro.domain.usecase.fake
 
 import com.escodro.domain.model.Category
 import com.escodro.domain.repository.CategoryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import java.util.TreeMap
 
 internal class CategoryRepositoryFake : CategoryRepository {
@@ -36,8 +38,8 @@ internal class CategoryRepositoryFake : CategoryRepository {
         categoryMap.clear()
     }
 
-    override suspend fun findAllCategories(): List<Category> =
-        categoryMap.values.toList()
+    override fun findAllCategories(): Flow<List<Category>> =
+        flowOf(categoryMap.values.toList())
 
     override suspend fun findCategoryById(categoryId: Long): Category? =
         categoryMap[categoryId]

--- a/data/local/src/main/java/com/escodro/local/dao/CategoryDao.kt
+++ b/data/local/src/main/java/com/escodro/local/dao/CategoryDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy.REPLACE
 import androidx.room.Query
 import androidx.room.Update
 import com.escodro.local.model.Category
+import kotlinx.coroutines.flow.Flow
 
 /**
  * DAO class to handle all [Category]-related database operations.
@@ -20,7 +21,7 @@ interface CategoryDao {
      * @return all inserted categories.
      */
     @Query("SELECT * FROM category")
-    suspend fun findAllCategories(): List<Category>
+    fun findAllCategories(): Flow<List<Category>>
 
     /**
      * Inserts a new category.

--- a/data/local/src/main/java/com/escodro/local/datasource/CategoryLocalDataSource.kt
+++ b/data/local/src/main/java/com/escodro/local/datasource/CategoryLocalDataSource.kt
@@ -4,6 +4,8 @@ import com.escodro.local.mapper.CategoryMapper
 import com.escodro.local.provider.DaoProvider
 import com.escodro.repository.datasource.CategoryDataSource
 import com.escodro.repository.model.Category
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 /**
  * Local implementation of [CategoryDataSource].
@@ -30,7 +32,7 @@ internal class CategoryLocalDataSource(
     override suspend fun cleanTable() =
         categoryDao.cleanTable()
 
-    override suspend fun findAllCategories(): List<Category> =
+    override fun findAllCategories(): Flow<List<Category>> =
         categoryDao.findAllCategories().map { categoryMapper.toRepo(it) }
 
     override suspend fun findCategoryById(categoryId: Long): Category? =

--- a/data/repository/src/main/java/com/escodro/repository/CategoryRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/escodro/repository/CategoryRepositoryImpl.kt
@@ -4,6 +4,8 @@ import com.escodro.domain.model.Category
 import com.escodro.domain.repository.CategoryRepository
 import com.escodro.repository.datasource.CategoryDataSource
 import com.escodro.repository.mapper.CategoryMapper
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 internal class CategoryRepositoryImpl(
     private val categoryDataSource: CategoryDataSource,
@@ -25,7 +27,7 @@ internal class CategoryRepositoryImpl(
     override suspend fun cleanTable() =
         categoryDataSource.cleanTable()
 
-    override suspend fun findAllCategories(): List<Category> =
+    override fun findAllCategories(): Flow<List<Category>> =
         categoryDataSource.findAllCategories().map { categoryMapper.toDomain(it) }
 
     override suspend fun findCategoryById(categoryId: Long): Category? =

--- a/data/repository/src/main/java/com/escodro/repository/datasource/CategoryDataSource.kt
+++ b/data/repository/src/main/java/com/escodro/repository/datasource/CategoryDataSource.kt
@@ -1,6 +1,7 @@
 package com.escodro.repository.datasource
 
 import com.escodro.repository.model.Category
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Interface to represent the implementation of Category data source.
@@ -45,7 +46,7 @@ interface CategoryDataSource {
      *
      * @return all inserted categories.
      */
-    suspend fun findAllCategories(): List<Category>
+    fun findAllCategories(): Flow<List<Category>>
 
     /**
      * Gets a specific category by id.

--- a/features/task/src/main/java/com/escodro/task/presentation/category/TaskCategoryViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/category/TaskCategoryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.escodro.domain.usecase.category.LoadAllCategories
 import com.escodro.task.mapper.CategoryMapper
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
 internal class TaskCategoryViewModel(
@@ -12,13 +13,13 @@ internal class TaskCategoryViewModel(
 ) : ViewModel() {
 
     fun loadCategories(): Flow<CategoryState> = flow {
-        val categoryList = loadAllCategories()
-
-        if (categoryList.isNotEmpty()) {
-            val mappedList = categoryMapper.toView(categoryList)
-            emit(CategoryState.Loaded(mappedList))
-        } else {
-            emit(CategoryState.Empty)
+        loadAllCategories().collect { categoryList ->
+            if (categoryList.isNotEmpty()) {
+                val mappedList = categoryMapper.toView(categoryList)
+                emit(CategoryState.Loaded(mappedList))
+            } else {
+                emit(CategoryState.Empty)
+            }
         }
     }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/fake/LoadAllCategoriesFake.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/fake/LoadAllCategoriesFake.kt
@@ -2,11 +2,13 @@ package com.escodro.task.presentation.fake
 
 import com.escodro.domain.model.Category
 import com.escodro.domain.usecase.category.LoadAllCategories
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 internal class LoadAllCategoriesFake : LoadAllCategories {
 
     var categoriesToBeReturned: List<Category> = listOf()
 
-    override suspend fun invoke(): List<Category> =
-        categoriesToBeReturned
+    override fun invoke(): Flow<List<Category>> =
+        flowOf(categoriesToBeReturned)
 }


### PR DESCRIPTION
[root-cause] The default categories are added to the database when the
user first open the app. Due to some database write delay, the screen
finished loading before that data is available to fetch.

[solution] Update the category fetch to return a Flow instead of a
suspend function of a list. This way, when the data is updated and ready
to be used, the Flow will emit an update to the UI recompose.