### PR TITLE
♻️ Rename lambdas for the present-tense

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
+++ b/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
@@ -37,8 +37,8 @@ fun NavGraph(startDestination: String = Destinations.Home) {
 
         composable(Destinations.Home) {
             Home(
-                onTaskClicked = actions.openTaskDetail,
-                onAboutClicked = actions.openAbout
+                onTaskClick = actions.openTaskDetail,
+                onAboutClick = actions.openAbout
             )
         }
 
@@ -49,12 +49,12 @@ fun NavGraph(startDestination: String = Destinations.Home) {
             val arguments = requireNotNull(backStackEntry.arguments)
             TaskDetailSection(
                 taskId = arguments.getLong(DestinationArgs.TaskId),
-                onUpPressed = actions.onUpPressed
+                onUpPress = actions.onUpPress
             )
         }
 
         composable(Destinations.About) {
-            About(onUpPressed = actions.onUpPressed)
+            About(onUpPress = actions.onUpPress)
         }
     }
 }
@@ -69,7 +69,7 @@ internal data class Actions(val navController: NavHostController) {
         navController.navigate(Destinations.About)
     }
 
-    val onUpPressed: () -> Unit = {
+    val onUpPress: () -> Unit = {
         navController.navigateUp()
     }
 }

--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -44,14 +44,14 @@ import com.escodro.theme.AlkaaTheme
  * Alkaa Home screen.
  */
 @Composable
-fun Home(onTaskClicked: (Long) -> Unit, onAboutClicked: () -> Unit) {
+fun Home(onTaskClick: (Long) -> Unit, onAboutClick: () -> Unit) {
     val (currentSection, setCurrentSection) = rememberSaveable { mutableStateOf(HomeSection.Tasks) }
     val navItems = HomeSection.values().toList()
     val homeModifier = Modifier.padding(bottom = 56.dp)
 
     val actions = HomeActions(
-        onTaskClicked = onTaskClicked,
-        onAboutClicked = onAboutClicked,
+        onTaskClick = onTaskClick,
+        onAboutClick = onAboutClick,
         setCurrentSection = setCurrentSection,
     )
 
@@ -86,7 +86,7 @@ private fun AlkaaHomeScaffold(
             bottomBar = {
                 AlkaaBottomNav(
                     currentSection = homeSection,
-                    onSectionSelected = actions.setCurrentSection,
+                    onSectionSelect = actions.setCurrentSection,
                     items = navItems
                 )
             }
@@ -107,12 +107,12 @@ private fun AlkaaContent(
         HomeSection.Tasks ->
             TaskListSection(
                 modifier = modifier,
-                onItemClicked = actions.onTaskClicked,
+                onItemClick = actions.onTaskClick,
                 bottomSheetContent = setSheetContent,
                 sheetState = sheetState
             )
         HomeSection.Search ->
-            SearchSection(modifier = modifier, onItemClicked = actions.onTaskClicked)
+            SearchSection(modifier = modifier, onItemClick = actions.onTaskClick)
         HomeSection.Categories ->
             CategoryListSection(
                 modifier = modifier,
@@ -122,7 +122,7 @@ private fun AlkaaContent(
         HomeSection.Settings ->
             PreferenceSection(
                 modifier = modifier,
-                onAboutClicked = actions.onAboutClicked
+                onAboutClick = actions.onAboutClick
             )
     }
 }
@@ -132,7 +132,7 @@ private fun AlkaaContent(
 private fun AlkaaBottomSheetLayout(
     sheetState: ModalBottomSheetState,
     bottomSheetContent: @Composable() () -> Unit,
-    content: @Composable() () -> Unit
+    content: @Composable () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
     DisposableEffect(sheetState.isVisible.not()) {
@@ -175,7 +175,7 @@ private fun AlkaaTopBar(currentSection: HomeSection) {
 @Composable
 private fun AlkaaBottomNav(
     currentSection: HomeSection,
-    onSectionSelected: (HomeSection) -> Unit,
+    onSectionSelect: (HomeSection) -> Unit,
     items: List<HomeSection>
 ) {
     BottomAppBar(backgroundColor = MaterialTheme.colors.background) {
@@ -191,7 +191,7 @@ private fun AlkaaBottomNav(
             AlkaaBottomIcon(
                 section = section,
                 tint = colorState.value,
-                onSectionSelected = onSectionSelected,
+                onSectionSelect = onSectionSelect,
                 modifier = Modifier.weight(1f)
             )
         }
@@ -202,12 +202,12 @@ private fun AlkaaBottomNav(
 private fun AlkaaBottomIcon(
     section: HomeSection,
     tint: Color,
-    onSectionSelected: (HomeSection) -> Unit,
+    onSectionSelect: (HomeSection) -> Unit,
     modifier: Modifier
 ) {
     val title = stringResource(section.title)
     IconButton(
-        onClick = { onSectionSelected(section) },
+        onClick = { onSectionSelect(section) },
         modifier = modifier
     ) {
         Icon(imageVector = section.icon, tint = tint, contentDescription = title)
@@ -230,7 +230,7 @@ fun AlkaaBottomNavPreview() {
     AlkaaTheme {
         AlkaaBottomNav(
             currentSection = HomeSection.Tasks,
-            onSectionSelected = {},
+            onSectionSelect = {},
             items = HomeSection.values().toList()
         )
     }

--- a/app/src/main/java/com/escodro/alkaa/presentation/home/HomeActions.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/HomeActions.kt
@@ -3,7 +3,7 @@ package com.escodro.alkaa.presentation.home
 import com.escodro.alkaa.model.HomeSection
 
 internal data class HomeActions(
-    val onTaskClicked: (Long) -> Unit = {},
-    val onAboutClicked: () -> Unit = {},
+    val onTaskClick: (Long) -> Unit = {},
+    val onAboutClick: () -> Unit = {},
     val setCurrentSection: (HomeSection) -> Unit = {}
 )

--- a/features/preference/src/androidTest/java/com/escodro/preference/AboutTest.kt
+++ b/features/preference/src/androidTest/java/com/escodro/preference/AboutTest.kt
@@ -32,7 +32,7 @@ internal class AboutTest {
     private fun loadView() {
         composeTestRule.setContent {
             AlkaaTheme {
-                About(onUpPressed = { })
+                About(onUpPress = { })
             }
         }
     }

--- a/features/preference/src/androidTest/java/com/escodro/preference/PreferenceSectionTest.kt
+++ b/features/preference/src/androidTest/java/com/escodro/preference/PreferenceSectionTest.kt
@@ -30,7 +30,7 @@ internal class PreferenceSectionTest {
     private fun loadView() {
         composeTestRule.setContent {
             AlkaaTheme {
-                PreferenceSection(onAboutClicked = { })
+                PreferenceSection(onAboutClick = { })
             }
         }
     }

--- a/features/preference/src/main/java/com/escodro/preference/presentation/About.kt
+++ b/features/preference/src/main/java/com/escodro/preference/presentation/About.kt
@@ -35,9 +35,9 @@ import java.util.Locale
  * Alkaa about screen.
  */
 @Composable
-fun About(onUpPressed: () -> Unit) {
+fun About(onUpPress: () -> Unit) {
     Scaffold(
-        topBar = { AlkaaToolbar(onUpPressed = onUpPressed) },
+        topBar = { AlkaaToolbar(onUpPress = onUpPress) },
         content = { AboutContent() }
     )
 }
@@ -100,6 +100,6 @@ private const val PROJECT_URL = "https://github.com/igorescodro/alkaa"
 @Composable
 fun AboutPreview() {
     AlkaaTheme {
-        About(onUpPressed = { })
+        About(onUpPress = { })
     }
 }

--- a/features/preference/src/main/java/com/escodro/preference/presentation/Preference.kt
+++ b/features/preference/src/main/java/com/escodro/preference/presentation/Preference.kt
@@ -23,12 +23,12 @@ import com.escodro.theme.AlkaaTheme
  * Alkaa Preference Section.
  *
  * @param modifier the decorator
- * @param onAboutClicked function to be called when the about item is clicked
+ * @param onAboutClick function to be called when the about item is clicked
  */
 @Composable
-fun PreferenceSection(modifier: Modifier = Modifier, onAboutClicked: () -> Unit) {
+fun PreferenceSection(modifier: Modifier = Modifier, onAboutClick: () -> Unit) {
     Column(modifier = modifier.fillMaxSize()) {
-        AboutItem(onAboutClicked)
+        AboutItem(onAboutClick)
         VersionItem()
     }
 }
@@ -41,10 +41,10 @@ private fun VersionItem() {
 }
 
 @Composable
-private fun AboutItem(onAboutClicked: () -> Unit) {
+private fun AboutItem(onAboutClick: () -> Unit) {
     PreferenceItem(
         title = stringResource(id = R.string.preference_title_about),
-        onItemClicked = onAboutClicked
+        onItemClick = onAboutClick
     )
 }
 
@@ -52,11 +52,11 @@ private fun AboutItem(onAboutClicked: () -> Unit) {
 private fun PreferenceItem(
     title: String,
     description: String? = null,
-    onItemClicked: () -> Unit = { }
+    onItemClick: () -> Unit = { }
 ) {
     Column(
         modifier = Modifier
-            .clickable { onItemClicked() }
+            .clickable { onItemClick() }
             .padding(start = 32.dp, top = 8.dp, end = 16.dp, bottom = 8.dp)
             .fillMaxWidth()
             .height(48.dp),
@@ -80,6 +80,6 @@ private fun PreferenceItem(
 @Composable
 fun PreferencePreview() {
     AlkaaTheme {
-        PreferenceSection(onAboutClicked = {})
+        PreferenceSection(onAboutClick = {})
     }
 }

--- a/features/search/src/androidTest/java/com/escodro/search/SearchSectionTest.kt
+++ b/features/search/src/androidTest/java/com/escodro/search/SearchSectionTest.kt
@@ -55,7 +55,7 @@ internal class SearchSectionTest {
             AlkaaTheme {
                 SearchScaffold(
                     viewState = state,
-                    onItemClicked = {},
+                    onItemClick = {},
                     query = "",
                     setQuery = {}
                 )

--- a/features/search/src/main/java/com/escodro/search/presentation/Search.kt
+++ b/features/search/src/main/java/com/escodro/search/presentation/Search.kt
@@ -50,14 +50,14 @@ import org.koin.androidx.compose.getViewModel
  * @param modifier the decorator
  */
 @Composable
-fun SearchSection(modifier: Modifier = Modifier, onItemClicked: (Long) -> Unit) {
-    SearchLoader(modifier = modifier, onItemClicked = onItemClicked)
+fun SearchSection(modifier: Modifier = Modifier, onItemClick: (Long) -> Unit) {
+    SearchLoader(modifier = modifier, onItemClick = onItemClick)
 }
 
 @Composable
 private fun SearchLoader(
     modifier: Modifier = Modifier,
-    onItemClicked: (Long) -> Unit,
+    onItemClick: (Long) -> Unit,
     viewModel: SearchViewModel = getViewModel()
 ) {
     val (query, setQuery) = rememberSaveable { mutableStateOf("") }
@@ -67,7 +67,7 @@ private fun SearchLoader(
     SearchScaffold(
         viewState = viewState,
         modifier = modifier,
-        onItemClicked = onItemClicked,
+        onItemClick = onItemClick,
         query = query,
         setQuery = setQuery
     )
@@ -77,7 +77,7 @@ private fun SearchLoader(
 internal fun SearchScaffold(
     modifier: Modifier = Modifier,
     viewState: SearchViewState,
-    onItemClicked: (Long) -> Unit,
+    onItemClick: (Long) -> Unit,
     query: String,
     setQuery: (String) -> Unit
 ) {
@@ -86,7 +86,7 @@ internal fun SearchScaffold(
         backgroundColor = MaterialTheme.colors.background
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            SearchTextField(query, onTextChanged = setQuery)
+            SearchTextField(query, onTextChange = setQuery)
 
             Crossfade(viewState) { state ->
                 when (state) {
@@ -94,7 +94,7 @@ internal fun SearchScaffold(
                     SearchViewState.Empty -> SearchEmptyContent()
                     is SearchViewState.Loaded -> SearchListContent(
                         taskList = state.taskList,
-                        onItemClicked = onItemClicked
+                        onItemClick = onItemClick
                     )
                 }
             }
@@ -103,10 +103,10 @@ internal fun SearchScaffold(
 }
 
 @Composable
-private fun SearchTextField(text: String, onTextChanged: (String) -> Unit) {
+private fun SearchTextField(text: String, onTextChange: (String) -> Unit) {
     TextField(
         value = text,
-        onValueChange = onTextChanged,
+        onValueChange = onTextChange,
         trailingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
@@ -130,22 +130,22 @@ private fun SearchEmptyContent() {
 }
 
 @Composable
-private fun SearchListContent(taskList: List<TaskSearchItem>, onItemClicked: (Long) -> Unit) {
+private fun SearchListContent(taskList: List<TaskSearchItem>, onItemClick: (Long) -> Unit) {
     LazyColumn {
         items(
             items = taskList,
-            itemContent = { task -> SearchItem(task = task, onItemClicked = onItemClicked) }
+            itemContent = { task -> SearchItem(task = task, onItemClick = onItemClick) }
         )
     }
 }
 
 @Composable
-private fun SearchItem(task: TaskSearchItem, onItemClicked: (Long) -> Unit) {
+private fun SearchItem(task: TaskSearchItem, onItemClick: (Long) -> Unit) {
     Column(
         modifier = Modifier
             .height(48.dp)
             .fillMaxWidth()
-            .clickable { onItemClicked(task.id) },
+            .clickable { onItemClick(task.id) },
         verticalArrangement = Arrangement.Center
     ) {
 
@@ -203,7 +203,7 @@ fun SearchLoadedListPreview() {
         SearchScaffold(
             modifier = Modifier,
             viewState = SearchViewState.Loaded(taskList),
-            onItemClicked = {},
+            onItemClick = {},
             query = "",
             setQuery = {}
         )
@@ -218,7 +218,7 @@ fun SearchEmptyListPreview() {
         SearchScaffold(
             modifier = Modifier,
             viewState = SearchViewState.Empty,
-            onItemClicked = {},
+            onItemClick = {},
             query = "",
             setQuery = {}
         )

--- a/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
@@ -143,8 +143,8 @@ internal class AlarmSelectionTest {
                     AlarmSelection(
                         calendar = null,
                         interval = AlarmInterval.NEVER,
-                        onAlarmUpdated = {},
-                        onIntervalSelected = {}
+                        onAlarmUpdate = {},
+                        onIntervalSelect = {}
                     )
                 }
             }
@@ -158,8 +158,8 @@ internal class AlarmSelectionTest {
                     AlarmSelection(
                         calendar = calendar,
                         interval = alarmInterval,
-                        onAlarmUpdated = {},
-                        onIntervalSelected = {}
+                        onAlarmUpdate = {},
+                        onIntervalSelect = {}
                     )
                 }
             }

--- a/features/task/src/androidTest/java/com/escodro/task/CategorySelectionTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/CategorySelectionTest.kt
@@ -106,7 +106,7 @@ internal class CategorySelectionTest {
                 CategorySelection(
                     state = CategoryState.Empty,
                     currentCategory = null,
-                    onCategoryChanged = { }
+                    onCategoryChange = { }
                 )
             }
         }
@@ -122,7 +122,7 @@ internal class CategorySelectionTest {
                 CategorySelection(
                     state = CategoryState.Loaded(categories),
                     currentCategory = currentCategory,
-                    onCategoryChanged = { }
+                    onCategoryChange = { }
                 )
             }
         }

--- a/features/task/src/androidTest/java/com/escodro/task/TaskItemTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/TaskItemTest.kt
@@ -69,7 +69,7 @@ internal class TaskItemTest {
     private fun loadItemView(item: TaskWithCategory, onItemClicked: (Long) -> Unit) {
         composeTestRule.setContent {
             AlkaaTheme {
-                TaskItem(Modifier, item, onItemClicked, onCheckedChanged = {})
+                TaskItem(Modifier, item, onItemClicked, onCheckedChange = {})
             }
         }
     }

--- a/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
@@ -69,7 +69,7 @@ internal fun AddTaskLoader(
         CategorySelection(
             state = categoryState,
             currentCategory = null,
-            onCategoryChanged = { categoryId -> currentCategory.value = categoryId }
+            onCategoryChange = { categoryId -> currentCategory.value = categoryId }
         )
 
         Button(

--- a/features/task/src/main/java/com/escodro/task/presentation/category/CategorySelection.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/category/CategorySelection.kt
@@ -37,7 +37,7 @@ import com.escodro.theme.components.AlkaaLoadingContent
 internal fun CategorySelection(
     state: CategoryState,
     currentCategory: Long?,
-    onCategoryChanged: (CategoryId) -> Unit,
+    onCategoryChange: (CategoryId) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -49,7 +49,7 @@ internal fun CategorySelection(
             is CategoryState.Loaded -> LoadedCategoryList(
                 categoryList = state.categoryList,
                 currentCategory = currentCategory,
-                onCategoryChanged = onCategoryChanged
+                onCategoryChange = onCategoryChange
             )
             CategoryState.Empty -> EmptyCategoryList()
         }
@@ -60,7 +60,7 @@ internal fun CategorySelection(
 private fun LoadedCategoryList(
     categoryList: List<Category>,
     currentCategory: Long?,
-    onCategoryChanged: (CategoryId) -> Unit
+    onCategoryChange: (CategoryId) -> Unit
 ) {
     val currentItem = categoryList.find { category -> category.id == currentCategory }
     val selectedState = remember { mutableStateOf(currentItem) }
@@ -73,7 +73,7 @@ private fun LoadedCategoryList(
                     category = category,
                     isSelected = isSelected,
                     selectedState,
-                    onCategoryChanged = { id -> onCategoryChanged(CategoryId(id)) }
+                    onCategoryChange = { id -> onCategoryChange(CategoryId(id)) }
                 )
             }
         )
@@ -93,7 +93,7 @@ private fun CategoryItemChip(
     category: Category,
     isSelected: Boolean = false,
     selectedState: MutableState<Category?>,
-    onCategoryChanged: (Long?) -> Unit
+    onCategoryChange: (Long?) -> Unit
 ) {
     Surface(
         modifier = Modifier.padding(end = 8.dp),
@@ -110,7 +110,7 @@ private fun CategoryItemChip(
                     onValueChange = {
                         val newCategory = toggleChip(selectedState, category)
                         selectedState.value = newCategory
-                        onCategoryChanged(newCategory?.id)
+                        onCategoryChange(newCategory?.id)
                     }
                 )
         ) {
@@ -158,7 +158,7 @@ fun CategorySelectionListPreview() {
             CategorySelection(
                 state = CategoryState.Loaded(categories),
                 currentCategory = category2.id,
-                onCategoryChanged = {}
+                onCategoryChange = {}
             )
         }
     }
@@ -173,7 +173,7 @@ fun CategorySelectionEmptyPreview() {
             CategorySelection(
                 state = CategoryState.Empty,
                 currentCategory = null,
-                onCategoryChanged = {}
+                onCategoryChange = {}
             )
         }
     }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/TaskDetailActions.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/TaskDetailActions.kt
@@ -5,10 +5,10 @@ import com.escodro.task.presentation.detail.main.CategoryId
 import java.util.Calendar
 
 internal data class TaskDetailActions(
-    val onTitleChanged: (String) -> Unit = {},
-    val onDescriptionChanged: (String) -> Unit = {},
-    val onCategoryChanged: (CategoryId) -> Unit = {},
-    val onAlarmUpdated: (Calendar?) -> Unit = {},
-    val onIntervalSelected: (AlarmInterval) -> Unit = {},
-    val onUpPressed: () -> Unit = {}
+    val onTitleChange: (String) -> Unit = {},
+    val onDescriptionChange: (String) -> Unit = {},
+    val onCategoryChange: (CategoryId) -> Unit = {},
+    val onAlarmUpdate: (Calendar?) -> Unit = {},
+    val onIntervalSelect: (AlarmInterval) -> Unit = {},
+    val onUpPress: () -> Unit = {}
 )

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
@@ -43,8 +43,8 @@ import java.util.Calendar
 internal fun AlarmSelection(
     calendar: Calendar?,
     interval: AlarmInterval?,
-    onAlarmUpdated: (Calendar?) -> Unit,
-    onIntervalSelected: (AlarmInterval) -> Unit
+    onAlarmUpdate: (Calendar?) -> Unit,
+    onIntervalSelect: (AlarmInterval) -> Unit
 ) {
     val context = LocalContext.current
     var date by remember { mutableStateOf(calendar) }
@@ -57,7 +57,7 @@ internal fun AlarmSelection(
                 .clickable {
                     DateTimePickerDialog(context) { calendar ->
                         date = calendar
-                        onAlarmUpdated(calendar)
+                        onAlarmUpdate(calendar)
                     }.show()
                 },
             imageVector = Icons.Outlined.CheckCircle,
@@ -76,7 +76,7 @@ internal fun AlarmSelection(
         if (date != null) {
             AlarmIntervalDialog(showDialog) { interval ->
                 alarmInterval = interval
-                onIntervalSelected(interval)
+                onIntervalSelect(interval)
             }
 
             TaskDetailSectionContent(
@@ -99,13 +99,13 @@ internal fun AlarmSelection(
 }
 
 @Composable
-private fun AlarmSet(date: Calendar?, onRemoveButtonClicked: () -> Unit) {
+private fun AlarmSet(date: Calendar?, onRemoveClick: () -> Unit) {
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
         Text(
             text = date?.format() ?: "",
             color = MaterialTheme.colors.onSecondary,
         )
-        IconButton(onClick = onRemoveButtonClicked) {
+        IconButton(onClick = onRemoveClick) {
             Icon(
                 imageVector = Icons.Outlined.Close,
                 contentDescription = stringResource(
@@ -129,7 +129,7 @@ private fun NoAlarmSet() {
 @Composable
 private fun AlarmIntervalDialog(
     showDialog: MutableState<Boolean>,
-    onIntervalSelected: (AlarmInterval) -> Unit
+    onIntervalSelect: (AlarmInterval) -> Unit
 ) {
     if (showDialog.value.not()) {
         return
@@ -149,7 +149,7 @@ private fun AlarmIntervalDialog(
                             title = title,
                             index = index,
                             showDialog = showDialog,
-                            onIntervalSelected = onIntervalSelected
+                            onIntervalSelect = onIntervalSelect
                         )
                     }
                 )
@@ -163,7 +163,7 @@ private fun AlarmListItem(
     title: String,
     index: Int,
     showDialog: MutableState<Boolean>,
-    onIntervalSelected: (AlarmInterval) -> Unit
+    onIntervalSelect: (AlarmInterval) -> Unit
 ) {
     Text(
         text = title,
@@ -174,7 +174,7 @@ private fun AlarmListItem(
                     AlarmInterval
                         .values()
                         .find { it.index == index } ?: AlarmInterval.NEVER
-                onIntervalSelected(interval)
+                onIntervalSelect(interval)
                 showDialog.value = false
             },
     )
@@ -189,8 +189,8 @@ fun AlarmSetSelectionPreview() {
             AlarmSelection(
                 Calendar.getInstance(),
                 AlarmInterval.WEEKLY,
-                onAlarmUpdated = {},
-                onIntervalSelected = {}
+                onAlarmUpdate = {},
+                onIntervalSelect = {}
             )
         }
     }
@@ -205,8 +205,8 @@ fun AlarmNotSetSelectionPreview() {
             AlarmSelection(
                 null,
                 AlarmInterval.NEVER,
-                onAlarmUpdated = {},
-                onIntervalSelected = {}
+                onAlarmUpdate = {},
+                onIntervalSelect = {}
             )
         }
     }
@@ -219,7 +219,7 @@ fun AlarmIntervalDialogPreview() {
     AlkaaTheme {
         AlarmIntervalDialog(
             showDialog = mutableStateOf(true),
-            onIntervalSelected = {}
+            onIntervalSelect = {}
         )
     }
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetail.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import com.escodro.categoryapi.model.Category
@@ -46,14 +45,14 @@ import org.koin.androidx.compose.getViewModel
  * @param taskId the id from the task to be shown
  */
 @Composable
-fun TaskDetailSection(taskId: Long, onUpPressed: () -> Unit) {
-    TaskDetailLoader(taskId = taskId, onUpPressed = onUpPressed)
+fun TaskDetailSection(taskId: Long, onUpPress: () -> Unit) {
+    TaskDetailLoader(taskId = taskId, onUpPress = onUpPress)
 }
 
 @Composable
 private fun TaskDetailLoader(
     taskId: Long,
-    onUpPressed: () -> Unit,
+    onUpPress: () -> Unit,
     detailViewModel: TaskDetailViewModel = getViewModel(),
     categoryViewModel: CategoryListViewModel = getViewModel(),
     alarmViewModel: TaskAlarmViewModel = getViewModel()
@@ -68,12 +67,12 @@ private fun TaskDetailLoader(
         .collectAsState(initial = CategoryState.Loading)
 
     val taskDetailActions = TaskDetailActions(
-        onTitleChanged = { title -> detailViewModel.updateTitle(id, title) },
-        onDescriptionChanged = { desc -> detailViewModel.updateDescription(id, desc) },
-        onCategoryChanged = { categoryId -> detailViewModel.updateCategory(id, categoryId) },
-        onAlarmUpdated = { calendar -> alarmViewModel.updateAlarm(id, calendar) },
-        onIntervalSelected = { interval -> alarmViewModel.setRepeating(id, interval) },
-        onUpPressed = onUpPressed
+        onTitleChange = { title -> detailViewModel.updateTitle(id, title) },
+        onDescriptionChange = { desc -> detailViewModel.updateDescription(id, desc) },
+        onCategoryChange = { categoryId -> detailViewModel.updateCategory(id, categoryId) },
+        onAlarmUpdate = { calendar -> alarmViewModel.updateAlarm(id, calendar) },
+        onIntervalSelect = { interval -> alarmViewModel.setRepeating(id, interval) },
+        onUpPress = onUpPress
     )
 
     TaskDetailRouter(
@@ -89,7 +88,7 @@ internal fun TaskDetailRouter(
     categoryViewState: CategoryState,
     actions: TaskDetailActions
 ) {
-    Scaffold(topBar = { AlkaaToolbar(onUpPressed = actions.onUpPressed) }) {
+    Scaffold(topBar = { AlkaaToolbar(onUpPress = actions.onUpPress) }) {
         Crossfade(detailViewState) { state ->
             when (state) {
                 TaskDetailState.Loading -> AlkaaLoadingContent()
@@ -113,7 +112,7 @@ private fun TaskDetailContent(
 ) {
     Surface(color = MaterialTheme.colors.background) {
         Column {
-            TaskTitleTextField(text = task.title, onTitleChanged = actions.onTitleChanged)
+            TaskTitleTextField(text = task.title, onTitleChange = actions.onTitleChange)
             TaskDetailSectionContent(
                 imageVector = Icons.Outlined.Create,
                 contentDescription = R.string.task_detail_cd_icon_category,
@@ -121,18 +120,18 @@ private fun TaskDetailContent(
                 CategorySelection(
                     state = categoryViewState,
                     currentCategory = task.categoryId,
-                    onCategoryChanged = actions.onCategoryChanged
+                    onCategoryChange = actions.onCategoryChange
                 )
             }
             TaskDescriptionTextField(
                 text = task.description,
-                onDescriptionChanged = actions.onDescriptionChanged
+                onDescriptionChange = actions.onDescriptionChange
             )
             AlarmSelection(
                 calendar = task.dueDate,
                 interval = task.alarmInterval,
-                onAlarmUpdated = actions.onAlarmUpdated,
-                onIntervalSelected = actions.onIntervalSelected
+                onAlarmUpdate = actions.onAlarmUpdate,
+                onIntervalSelect = actions.onIntervalSelect
             )
         }
     }
@@ -148,14 +147,14 @@ private fun TaskDetailError() {
 }
 
 @Composable
-private fun TaskTitleTextField(text: String, onTitleChanged: (String) -> Unit) {
+private fun TaskTitleTextField(text: String, onTitleChange: (String) -> Unit) {
     val textState = remember { mutableStateOf(TextFieldValue(text)) }
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = textState.value,
         onValueChange = {
-            onTitleChanged(it.text)
+            onTitleChange(it.text)
             textState.value = it
         },
         textStyle = MaterialTheme.typography.h4,
@@ -164,7 +163,7 @@ private fun TaskTitleTextField(text: String, onTitleChanged: (String) -> Unit) {
 }
 
 @Composable
-private fun TaskDescriptionTextField(text: String?, onDescriptionChanged: (String) -> Unit) {
+private fun TaskDescriptionTextField(text: String?, onDescriptionChange: (String) -> Unit) {
     val textState = remember { mutableStateOf(TextFieldValue(text ?: "")) }
 
     TextField(
@@ -177,7 +176,7 @@ private fun TaskDescriptionTextField(text: String?, onDescriptionChanged: (Strin
         },
         value = textState.value,
         onValueChange = {
-            onDescriptionChanged(it.text)
+            onDescriptionChange(it.text)
             textState.value = it
         },
         textStyle = MaterialTheme.typography.body1,

--- a/features/task/src/main/java/com/escodro/task/presentation/list/CategoryStateHandler.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/CategoryStateHandler.kt
@@ -6,5 +6,5 @@ import com.escodro.task.presentation.detail.main.CategoryId
 internal data class CategoryStateHandler(
     val state: CategoryState = CategoryState.Empty,
     val currentCategory: CategoryId? = null,
-    val onCategoryChanged: (CategoryId?) -> Unit = {},
+    val onCategoryChange: (CategoryId?) -> Unit = {},
 )

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -50,24 +50,24 @@ import java.util.Calendar
 @Composable
 fun TaskListSection(
     modifier: Modifier = Modifier,
-    onItemClicked: (Long) -> Unit,
+    onItemClick: (Long) -> Unit,
     bottomSheetContent: (@Composable () -> Unit) -> Unit,
     sheetState: ModalBottomSheetState
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val onAddClicked: () -> Unit = {
+    val onAddClick: () -> Unit = {
         coroutineScope.launch { sheetState.show() }
         bottomSheetContent { AddTaskSection(sheetState = sheetState) }
     }
 
-    TaskListLoader(modifier = modifier, onItemClicked = onItemClicked, onAddClicked = onAddClicked)
+    TaskListLoader(modifier = modifier, onItemClick = onItemClick, onAddClick = onAddClick)
 }
 
 @Composable
 private fun TaskListLoader(
     modifier: Modifier = Modifier,
-    onItemClicked: (Long) -> Unit,
-    onAddClicked: () -> Unit,
+    onItemClick: (Long) -> Unit,
+    onAddClick: () -> Unit,
     taskListViewModel: TaskListViewModel = getViewModel(),
     categoryViewModel: CategoryListViewModel = getViewModel(),
 ) {
@@ -82,15 +82,15 @@ private fun TaskListLoader(
 
     val taskHandler = TaskStateHandler(
         state = taskViewState,
-        onCheckedChanged = taskListViewModel::updateTaskStatus,
-        onItemClicked = onItemClicked,
-        onAddClicked = onAddClicked
+        onCheckedChange = taskListViewModel::updateTaskStatus,
+        onItemClick = onItemClick,
+        onAddClick = onAddClick
     )
 
     val categoryHandler = CategoryStateHandler(
         state = categoryViewState,
         currentCategory = currentCategory,
-        onCategoryChanged = setCategory,
+        onCategoryChange = setCategory,
     )
 
     TaskListScaffold(
@@ -110,7 +110,7 @@ internal fun TaskListScaffold(
         modifier = modifier.fillMaxSize(),
         backgroundColor = MaterialTheme.colors.background,
         topBar = { TaskFilter(categoryHandler = categoryHandler) },
-        floatingActionButton = { FloatingButton { taskHandler.onAddClicked() } },
+        floatingActionButton = { FloatingButton { taskHandler.onAddClick() } },
         floatingActionButtonPosition = FabPosition.Center
     ) {
         Crossfade(taskHandler.state) { state ->
@@ -121,8 +121,8 @@ internal fun TaskListScaffold(
                     val taskList = state.items
                     TaskListContent(
                         taskList,
-                        taskHandler.onItemClicked,
-                        taskHandler.onCheckedChanged
+                        taskHandler.onItemClick,
+                        taskHandler.onCheckedChange
                     )
                 }
                 TaskListViewState.Empty -> TaskListEmpty()
@@ -136,7 +136,7 @@ private fun TaskFilter(categoryHandler: CategoryStateHandler) {
     CategorySelection(
         state = categoryHandler.state,
         currentCategory = categoryHandler.currentCategory?.value,
-        onCategoryChanged = categoryHandler.onCategoryChanged,
+        onCategoryChange = categoryHandler.onCategoryChange,
         modifier = Modifier.padding(start = 16.dp)
     )
 }
@@ -144,8 +144,8 @@ private fun TaskFilter(categoryHandler: CategoryStateHandler) {
 @Composable
 private fun TaskListContent(
     taskList: List<TaskWithCategory>,
-    onItemClicked: (Long) -> Unit,
-    onCheckedChanged: (TaskWithCategory) -> Unit
+    onItemClick: (Long) -> Unit,
+    onCheckedChange: (TaskWithCategory) -> Unit
 ) {
     Column(modifier = Modifier.padding(start = 8.dp, end = 8.dp)) {
         LazyColumn(contentPadding = PaddingValues(bottom = 48.dp)) {
@@ -154,8 +154,8 @@ private fun TaskListContent(
                 itemContent = { task ->
                     TaskItem(
                         task = task,
-                        onItemClicked = onItemClicked,
-                        onCheckedChanged = onCheckedChanged
+                        onItemClick = onItemClick,
+                        onCheckedChange = onCheckedChange
                     )
                 }
             )

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskListComponents.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskListComponents.kt
@@ -39,14 +39,14 @@ import java.util.Calendar
  *
  * @param modifier the decorator
  * @param task the task item to be rendered
- * @param onItemClicked the action to be done when the item is clicked
+ * @param onItemClick the action to be done when the item is clicked
  */
 @Composable
 internal fun TaskItem(
     modifier: Modifier = Modifier,
     task: TaskWithCategory,
-    onItemClicked: (Long) -> Unit,
-    onCheckedChanged: (TaskWithCategory) -> Unit
+    onItemClick: (Long) -> Unit,
+    onCheckedChange: (TaskWithCategory) -> Unit
 ) {
     Card(
         elevation = 4.dp,
@@ -54,14 +54,14 @@ internal fun TaskItem(
             .fillMaxWidth()
             .padding(all = 8.dp)
             .height(74.dp)
-            .clickable { onItemClicked(task.task.id) }
+            .clickable { onItemClick(task.task.id) }
     ) {
         Row {
             CardRibbon(colorInt = task.category?.color)
             Checkbox(
                 modifier = modifier.fillMaxHeight(),
                 checked = task.task.completed,
-                onCheckedChange = { onCheckedChanged(task) }
+                onCheckedChange = { onCheckedChange(task) }
             )
             Spacer(Modifier.width(8.dp))
             Column(modifier = modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
@@ -135,7 +135,7 @@ fun TaskItemPreview() {
     TaskItem(
         modifier = Modifier,
         task = taskWithCategory,
-        onCheckedChanged = {},
-        onItemClicked = {}
+        onCheckedChange = {},
+        onItemClick = {}
     )
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskStateHandler.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskStateHandler.kt
@@ -4,7 +4,7 @@ import com.escodro.task.model.TaskWithCategory
 
 internal data class TaskStateHandler(
     val state: TaskListViewState = TaskListViewState.Empty,
-    val onCheckedChanged: (TaskWithCategory) -> Unit = {},
-    val onItemClicked: (Long) -> Unit = {},
-    val onAddClicked: () -> Unit = {},
+    val onCheckedChange: (TaskWithCategory) -> Unit = {},
+    val onItemClick: (Long) -> Unit = {},
+    val onAddClick: () -> Unit = {},
 )

--- a/libraries/theme/src/main/java/com/escodro/theme/components/AlkaaComponents.kt
+++ b/libraries/theme/src/main/java/com/escodro/theme/components/AlkaaComponents.kt
@@ -71,12 +71,12 @@ fun AlkaaLoadingContent() {
 /**
  * TopAppBar for screens that need a back button.
  *
- * @param onUpPressed function to be called when the back/up button is clicked
+ * @param onUpPress function to be called when the back/up button is clicked
  */
 @Composable
-fun AlkaaToolbar(onUpPressed: () -> Unit) {
+fun AlkaaToolbar(onUpPress: () -> Unit) {
     TopAppBar(backgroundColor = Color.Transparent, elevation = 0.dp) {
-        IconButton(onClick = onUpPressed, modifier = Modifier.align(Alignment.CenterVertically)) {
+        IconButton(onClick = onUpPress, modifier = Modifier.align(Alignment.CenterVertically)) {
             Icon(
                 imageVector = Icons.Rounded.ArrowBack,
                 contentDescription = stringResource(id = R.string.back_arrow_content_description)


### PR DESCRIPTION
The official documentation states that the lambdas should be renamed in
present rather than in past tense, "as the event doesn't mean the state
has already changed, but rather that the composable is requesting that
the event handler change it."