### PR TITLE
⬆️ Upgrade Compose to latest Beta

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
 
     const val espresso = "3.3.0"
 
-    const val compose = "1.0.0-beta02"
+    const val compose = "1.0.0-beta03"
     const val composeNav = "1.0.0-alpha09"
     const val composeViewModel = "1.0.0-alpha03"
     const val composeActivity = "1.3.0-alpha04"


### PR DESCRIPTION
Compose updated to Beta-03 and all Compose-related libraries upgraded
to its respective versions.