### PR TITLE
✅ Remove flakiness from AlarmSelectionTest

### DIFF
--- a/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
@@ -13,8 +13,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.task.espresso.setDateTime
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.alarm.AlarmSelection
+import com.escodro.test.DisableAnimationsRule
 import com.escodro.theme.AlkaaTheme
-import com.schibsted.spain.barista.rule.flaky.FlakyTestRule
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -26,10 +26,8 @@ internal class AlarmSelectionTest {
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
 
-    // Unfortunately due to integration between Compose and Android View System, the test
-    // sometime fails due to delay in opening Date and TimePicker.
     @get:Rule
-    val flakyRule = FlakyTestRule().allowFlakyAttemptsByDefault(defaultAttempts = 10)
+    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/features/task/src/androidTest/java/com/escodro/task/espresso/Events.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/espresso/Events.kt
@@ -2,11 +2,14 @@ package com.escodro.task.espresso
 
 import com.schibsted.spain.barista.interaction.BaristaPickerInteractions.setDateOnPicker
 import com.schibsted.spain.barista.interaction.BaristaPickerInteractions.setTimeOnPicker
+import com.schibsted.spain.barista.interaction.BaristaSleepInteractions
 import java.util.Calendar
 
 internal fun setDateTime(calendar: Calendar) {
     with(calendar) {
+        BaristaSleepInteractions.sleep(300)
         setDateOnPicker(get(Calendar.YEAR), get(Calendar.MONTH) + 1, get(Calendar.DAY_OF_MONTH))
+        BaristaSleepInteractions.sleep(300)
         setTimeOnPicker(get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE))
     }
 }

--- a/libraries/test/build.gradle
+++ b/libraries/test/build.gradle
@@ -26,4 +26,7 @@ dependencies {
         exclude group: "androidx.activity", module: "activity"
         exclude group: "androidx.lifecycle", module: "lifecycle-runtime"
     }
+
+    implementation Deps.test.core
+    implementation Deps.test.uiAutomator
 }

--- a/libraries/test/src/main/java/com/escodro/test/DisableAnimationsRule.kt
+++ b/libraries/test/src/main/java/com/escodro/test/DisableAnimationsRule.kt
@@ -1,0 +1,39 @@
+package com.escodro.test
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * [TestRule] to disable the animations during the tests and enable again after finishing.
+ */
+class DisableAnimationsRule : TestRule {
+
+    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    override fun apply(base: Statement?, description: Description?): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                disableAnimations()
+                try {
+                    base?.evaluate()
+                } finally {
+                    enableAnimations()
+                }
+            }
+        }
+
+    private fun disableAnimations() {
+        uiDevice.executeShellCommand("settings put global transition_animation_scale 0")
+        uiDevice.executeShellCommand("settings put global window_animation_scale 0")
+        uiDevice.executeShellCommand("settings put global animator_duration_scale 0")
+    }
+
+    private fun enableAnimations() {
+        uiDevice.executeShellCommand("settings put global transition_animation_scale 1")
+        uiDevice.executeShellCommand("settings put global window_animation_scale 1")
+        uiDevice.executeShellCommand("settings put global animator_duration_scale 1")
+    }
+}


### PR DESCRIPTION
Add the Test Rule to disable animations when using components from
Android View System.