### PR TITLE
⬆️ Upgrade Android Gradle Plugin

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -37,7 +37,7 @@ object Versions {
     const val composeViewModel = "1.0.0-alpha04"
     const val composeActivity = "1.3.0-alpha06"
 
-    const val buildGradle = "7.0.0-alpha13"
+    const val buildGradle = "7.0.0-alpha14"
 
     const val detekt = "1.13.1"
     const val ktlint = "0.39.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 25 08:48:27 BRT 2021
+#Fri Apr 09 08:19:14 BRT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Android Gradle Plugin updated to 7.0.0-alpha14 to match latest Android
Studio version