### PR TITLE
🗑️ Remove JCenter in favor of MavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -28,9 +28,7 @@ object Versions {
     const val testUiAutomator = "2.2.0"
     const val testJunitExt = "1.1.0"
     const val testRoom = "2.1.0"
-    const val barista = "3.7.0"
-
-    const val espresso = "3.3.0"
+    const val barista = "4.0.0"
 
     const val compose = "1.0.0"
     const val composeNav = "2.4.0-alpha01"
@@ -39,7 +37,7 @@ object Versions {
 
     const val buildGradle = "7.1.0-alpha08"
 
-    const val detekt = "1.13.1"
+    const val detekt = "1.17.1"
     const val ktlint = "0.39.0"
 }
 
@@ -103,7 +101,7 @@ object TestDeps {
     val junitExt = "androidx.test.ext:junit:${Versions.testJunitExt}"
     val mockk = "io.mockk:mockk:${Versions.testMockk}"
     val room = "androidx.room:room-testing:${Versions.testRoom}"
-    val barista = "com.schibsted.spain:barista:${Versions.espresso}"
+    val barista = "com.adevinta.android:barista:${Versions.barista}"
 }
 
 object QualityDeps {

--- a/features/task/src/androidTest/java/com/escodro/task/espresso/Events.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/espresso/Events.kt
@@ -1,8 +1,8 @@
 package com.escodro.task.espresso
 
-import com.schibsted.spain.barista.interaction.BaristaPickerInteractions.setDateOnPicker
-import com.schibsted.spain.barista.interaction.BaristaPickerInteractions.setTimeOnPicker
-import com.schibsted.spain.barista.interaction.BaristaSleepInteractions
+import com.adevinta.android.barista.interaction.BaristaPickerInteractions.setDateOnPicker
+import com.adevinta.android.barista.interaction.BaristaPickerInteractions.setTimeOnPicker
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import java.util.Calendar
 
 internal fun setDateTime(calendar: Calendar) {


### PR DESCRIPTION
Once JCenter will be turned off in 2022 and all the dependencies used in
Alkaa were already ported, it was replaced by Maven Central instead.