### PR TITLE
✨ Close BottomSheet when back is pressed

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/core/Handlers.kt
+++ b/app/src/main/java/com/escodro/alkaa/core/Handlers.kt
@@ -1,0 +1,41 @@
+package com.escodro.alkaa.core
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Handles the back pressed action.
+ *
+ * @param onBackPressed function to be called when the back is pressed
+ */
+@Composable
+fun BackPressHandler(onBackPressed: () -> Unit) {
+    val currentOnBackPressed by rememberUpdatedState(onBackPressed)
+
+    val backCallback = remember {
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                currentOnBackPressed()
+            }
+        }
+    }
+
+    val backDispatcher = LocalBackPressedDispatcher.current
+
+    DisposableEffect(backDispatcher) {
+        backDispatcher.addCallback(backCallback)
+        onDispose { backCallback.remove() }
+    }
+}
+
+/**
+ * Provides a [OnBackPressedDispatcher] that can be used by Android applications.
+ */
+val LocalBackPressedDispatcher =
+    staticCompositionLocalOf<OnBackPressedDispatcher> { error("No Back Dispatcher provided") }

--- a/app/src/main/java/com/escodro/alkaa/presentation/MainActivity.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/MainActivity.kt
@@ -3,6 +3,8 @@ package com.escodro.alkaa.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.CompositionLocalProvider
+import com.escodro.alkaa.core.LocalBackPressedDispatcher
 import com.escodro.alkaa.navigation.NavGraph
 import com.escodro.designsystem.AlkaaTheme
 
@@ -15,7 +17,11 @@ internal class MainActivity : ComponentActivity() {
 
         setContent {
             AlkaaTheme {
-                NavGraph()
+                CompositionLocalProvider(
+                    LocalBackPressedDispatcher provides onBackPressedDispatcher
+                ) {
+                    NavGraph()
+                }
             }
         }
     }

--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.escodro.alkaa.core.BackPressHandler
 import com.escodro.alkaa.model.HomeSection
 import com.escodro.category.presentation.bottomsheet.CategoryBottomSheet
 import com.escodro.category.presentation.list.CategoryListSection
@@ -103,6 +104,10 @@ private fun AlkaaHomeScaffold(
     }
 
     val onHideBottomSheet: () -> Unit = { coroutineScope.launch { modalSheetState.hide() } }
+
+    if (modalSheetState.isVisible) {
+        BackPressHandler { coroutineScope.launch { modalSheetState.hide() } }
+    }
 
     AlkaaBottomSheetLayout(
         modalSheetState = modalSheetState,


### PR DESCRIPTION
In the previous implementation, if the BottomSheet was opened and the
user presses the back button, the app was closed. Now, if the
BottomSheet is opened, it will first close it and only then it will
close the application.