### PR TITLE
🐞 BottomSheet crashes when rotating from landscape

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -2,12 +2,13 @@ package com.escodro.alkaa.presentation.home
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BottomAppBar
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
@@ -144,23 +145,24 @@ private fun AlkaaBottomSheetLayout(
         sheetState = modalSheetState,
         sheetBackgroundColor = Color.Transparent,
         sheetContent = {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(256.dp)
-                    .padding(horizontal = 2.dp)
-                    .clickable { /* consume click in the sheet background to avoid dismissal */ }
-            ) {
-                when (sheetContentState) {
-                    SheetContentState.TaskListSheet ->
-                        AddTaskBottomSheet(onHideBottomSheet = onHideBottomSheet)
-                    is SheetContentState.CategorySheet ->
-                        CategoryBottomSheet(
-                            category = sheetContentState.category,
-                            onHideBottomSheet = onHideBottomSheet
-                        )
-                    SheetContentState.Empty ->
-                        Box(modifier = Modifier.fillMaxSize())
+            BoxWithConstraints {
+                val cardFraction = if (this.maxHeight > maxWidth) 0.333F else 0.5F
+                Card(
+                    modifier = Modifier
+                        .fillMaxHeight(fraction = cardFraction)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    when (sheetContentState) {
+                        SheetContentState.TaskListSheet ->
+                            AddTaskBottomSheet(onHideBottomSheet = onHideBottomSheet)
+                        is SheetContentState.CategorySheet ->
+                            CategoryBottomSheet(
+                                category = sheetContentState.category,
+                                onHideBottomSheet = onHideBottomSheet
+                            )
+                        SheetContentState.Empty ->
+                            Box(modifier = Modifier.fillMaxSize())
+                    }
                 }
             }
         }

--- a/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
+++ b/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -111,7 +112,12 @@ private fun CategorySheetContent(
     onCategoryChange: (CategoryBottomSheetState) -> Unit,
     onCategoryRemove: (Category) -> Unit
 ) {
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.SpaceAround) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceAround
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
 
             var openDialog by rememberSaveable { mutableStateOf(false) }
@@ -171,6 +177,7 @@ private fun CategoryColorSelector(
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
+            .height(56.dp)
             .padding(top = 16.dp)
     ) {
         items(

--- a/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
@@ -3,6 +3,7 @@ package com.escodro.task.presentation.add
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -52,7 +53,9 @@ internal fun AddTaskLoader(
     onHideBottomSheet: () -> Unit
 ) {
     Column(
-        modifier = Modifier.padding(16.dp),
+        modifier = Modifier
+            .fillMaxHeight()
+            .padding(16.dp),
         verticalArrangement = Arrangement.SpaceAround
     ) {
         var taskInputText by rememberSaveable { mutableStateOf("") }


### PR DESCRIPTION
[root-cause] When the device is in landscape with the BottomSheet opened
and the user rotates the device, it crashes with the following message:

 java.lang.IllegalArgumentException: The initial value must have an
 associated anchor.

 [solution] Although we don't have an official solution for this issue
 (see linked IssueTracker), I was able to find a workaround to avoid
 this bug.

 First of all, I used a `BoxWithConstraints` to know exactly when the
 device is in landscape mode. When in landscape, the
 `ModalBottomSheetLayout` has a weird behavior related to its height: it
 allows only `fillMaxHeight` or values lower the half screen. Since I
 don't want the BottomSheet to be fullscreen, I updated the code with
 using fractions of the screen. When the app is in portrait, it uses
 one value and when in landscape, other one.
 I also added a vertical scroll on the card. Not the best approach
 in UI point of view, but it will help users in landscape.