### PR TITLE
Revert "🐞 BottomSheet crashes when rotating from landscape (#193)"

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -2,13 +2,12 @@ package com.escodro.alkaa.presentation.home
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BottomAppBar
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
@@ -145,24 +144,23 @@ private fun AlkaaBottomSheetLayout(
         sheetState = modalSheetState,
         sheetBackgroundColor = Color.Transparent,
         sheetContent = {
-            BoxWithConstraints {
-                val cardFraction = if (this.maxHeight > maxWidth) 0.333F else 0.5F
-                Card(
-                    modifier = Modifier
-                        .fillMaxHeight(fraction = cardFraction)
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    when (sheetContentState) {
-                        SheetContentState.TaskListSheet ->
-                            AddTaskBottomSheet(onHideBottomSheet = onHideBottomSheet)
-                        is SheetContentState.CategorySheet ->
-                            CategoryBottomSheet(
-                                category = sheetContentState.category,
-                                onHideBottomSheet = onHideBottomSheet
-                            )
-                        SheetContentState.Empty ->
-                            Box(modifier = Modifier.fillMaxSize())
-                    }
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(256.dp)
+                    .padding(horizontal = 2.dp)
+                    .clickable { /* consume click in the sheet background to avoid dismissal */ }
+            ) {
+                when (sheetContentState) {
+                    SheetContentState.TaskListSheet ->
+                        AddTaskBottomSheet(onHideBottomSheet = onHideBottomSheet)
+                    is SheetContentState.CategorySheet ->
+                        CategoryBottomSheet(
+                            category = sheetContentState.category,
+                            onHideBottomSheet = onHideBottomSheet
+                        )
+                    SheetContentState.Empty ->
+                        Box(modifier = Modifier.fillMaxSize())
                 }
             }
         }

--- a/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
+++ b/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -112,12 +111,7 @@ private fun CategorySheetContent(
     onCategoryChange: (CategoryBottomSheetState) -> Unit,
     onCategoryRemove: (Category) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxHeight()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.SpaceAround
-    ) {
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.SpaceAround) {
         Row(verticalAlignment = Alignment.CenterVertically) {
 
             var openDialog by rememberSaveable { mutableStateOf(false) }
@@ -177,7 +171,6 @@ private fun CategoryColorSelector(
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .height(56.dp)
             .padding(top = 16.dp)
     ) {
         items(

--- a/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/add/AddTask.kt
@@ -3,7 +3,6 @@ package com.escodro.task.presentation.add
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -53,9 +52,7 @@ internal fun AddTaskLoader(
     onHideBottomSheet: () -> Unit
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxHeight()
-            .padding(16.dp),
+        modifier = Modifier.padding(16.dp),
         verticalArrangement = Arrangement.SpaceAround
     ) {
         var taskInputText by rememberSaveable { mutableStateOf("") }


### PR DESCRIPTION
This reverts commit 5bf2b6ce

In the Compose 1.0.0-RC01, the BottomSheet issue was kinda fixed.
When rotating the screen with a BottomSheet opened, it simply
closes. This solves the crash issue and I hope that Google will
improve this behavior in the future.