### PR TITLE
🔥 Remove BottomSheet clickable workaround

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -2,7 +2,6 @@ package com.escodro.alkaa.presentation.home
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -149,7 +148,6 @@ private fun AlkaaBottomSheetLayout(
                     .fillMaxWidth()
                     .height(256.dp)
                     .padding(horizontal = 2.dp)
-                    .clickable { /* consume click in the sheet background to avoid dismissal */ }
             ) {
                 when (sheetContentState) {
                     SheetContentState.TaskListSheet ->


### PR DESCRIPTION
In the earlier versions of Jetpack Compose, the BottomSheet background
would consume the click button and dismiss it. Then I added a empty
click event to ignore this behavior. Now in latest versions this issue
was fixed and the workaround can be now removed.