### PR TITLE
⬆️ Enable Gradle's Type-safe Project Accessors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,19 +52,19 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(":libraries:splitInstall")
-    implementation project(':libraries:designsystem')
-    implementation project(":libraries:navigation")
-    implementation project(":data:local")
-    implementation project(":data:repository")
-    implementation project(":domain")
-    implementation project(":features:task")
-    implementation project(":features:alarm")
-    implementation project(":features:category-api")
-    implementation project(":features:category")
-    implementation project(":features:preference")
-    implementation project(":features:search")
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.splitInstall)
+    implementation(projects.libraries.designsystem)
+    implementation(projects.libraries.navigation)
+    implementation(projects.data.local)
+    implementation(projects.data.repository)
+    implementation(projects.domain)
+    implementation(projects.features.task)
+    implementation(projects.features.alarm)
+    implementation(projects.features.categoryApi)
+    implementation(projects.features.category)
+    implementation(projects.features.preference)
+    implementation(projects.features.search)
 
     implementation Deps.compose.navigation
     implementation Deps.compose.activity

--- a/config/dependencies/dynamic_dependencies.gradle
+++ b/config/dependencies/dynamic_dependencies.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.dynamic-feature'
 apply from: "$rootDir/config/dependencies/android_dependencies.gradle"
 
 dependencies {
-    implementation project(":app")
-    androidTestImplementation project(":app")
+    implementation(projects.app)
+    androidTestImplementation(projects.app)
 
     implementation Deps.android.playCore
 }

--- a/data/local/build.gradle
+++ b/data/local/build.gradle
@@ -18,8 +18,8 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(":data:repository")
+    implementation(projects.libraries.core)
+    implementation(projects.data.repository)
 
     implementation Deps.koin.android
     implementation Deps.android.room.runtime

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'kotlin'
 apply from: "$rootDir/config/quality.gradle"
 
 dependencies {
-    implementation project(":domain")
+    implementation(projects.domain)
 
     implementation Deps.koin.core
     implementation Deps.coroutines.core

--- a/features/alarm/build.gradle
+++ b/features/alarm/build.gradle
@@ -7,9 +7,9 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(":libraries:navigation")
-    implementation project(":domain")
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.navigation)
+    implementation(projects.domain)
 
     implementation Deps.coroutines.core
     implementation Deps.koin.android

--- a/features/category/build.gradle
+++ b/features/category/build.gradle
@@ -15,13 +15,13 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(":features:category-api")
-    implementation project(":domain")
-    implementation project(':libraries:designsystem')
+    implementation(projects.libraries.core)
+    implementation(projects.features.categoryApi)
+    implementation(projects.domain)
+    implementation(projects.libraries.designsystem)
 
-    testImplementation project(":libraries:test")
-    androidTestImplementation project(":libraries:test")
+    testImplementation(projects.libraries.test)
+    androidTestImplementation(projects.libraries.test)
 
     implementation Deps.koin.android
     implementation Deps.koin.compose

--- a/features/preference/build.gradle
+++ b/features/preference/build.gradle
@@ -13,9 +13,9 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(':libraries:designsystem')
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.designsystem)
 
-    testImplementation project(":libraries:test")
-    androidTestImplementation project(":libraries:test")
+    testImplementation(projects.libraries.test)
+    androidTestImplementation(projects.libraries.test)
 }

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -13,13 +13,13 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
-    implementation project(":domain")
-    implementation project(':libraries:designsystem')
+    implementation(projects.libraries.core)
+    implementation(projects.domain)
+    implementation(projects.libraries.designsystem)
 
     implementation Deps.koin.android
     implementation Deps.koin.compose
 
-    testImplementation project(":libraries:test")
-    androidTestImplementation project(":libraries:test")
+    testImplementation(projects.libraries.test)
+    androidTestImplementation(projects.libraries.test)
 }

--- a/features/task/build.gradle
+++ b/features/task/build.gradle
@@ -14,13 +14,13 @@ android {
 }
 
 dependencies {
-    implementation project(":features:category-api")
-    implementation project(":libraries:core")
-    implementation project(":domain")
-    implementation project(':libraries:designsystem')
+    implementation(projects.features.categoryApi)
+    implementation(projects.libraries.core)
+    implementation(projects.domain)
+    implementation(projects.libraries.designsystem)
 
-    testImplementation project(":libraries:test")
-    androidTestImplementation project(":libraries:test")
+    testImplementation(projects.libraries.test)
+    androidTestImplementation(projects.libraries.test)
 
     implementation Deps.android.playCore
 

--- a/features/tracker/build.gradle
+++ b/features/tracker/build.gradle
@@ -13,13 +13,13 @@ android {
 }
 
 dependencies {
-    implementation project(":domain")
-    implementation project(':libraries:designsystem')
+    implementation(projects.domain)
+    implementation(projects.libraries.designsystem)
 
     implementation Deps.koin.android
     implementation Deps.coroutines.core
     implementation Deps.koin.compose
     implementation Deps.compose.activity
 
-    testImplementation project(':libraries:test')
+    testImplementation(projects.libraries.test)
 }

--- a/libraries/splitInstall/build.gradle
+++ b/libraries/splitInstall/build.gradle
@@ -1,7 +1,7 @@
 apply from: "$rootDir/config/dependencies/feature_dependencies.gradle"
 
 dependencies {
-    implementation project(":libraries:core")
+    implementation(projects.libraries.core)
 
     implementation Deps.android.constraintLayout
     implementation Deps.android.playCore

--- a/libraries/test/build.gradle
+++ b/libraries/test/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    implementation project(":libraries:core")
+    implementation(projects.libraries.core)
 
     api Deps.test.junit
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,5 @@ include ':libraries:test'
 include ':libraries:splitInstall'
 include ':libraries:designsystem'
 include ':libraries:navigation'
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Enable the new feature on Gradle 7.0 and update all the projects
references form hardcoded to type-safe calls.