### PR TITLE
♻️ Remove GlobalScope references from the codebase

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
+++ b/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
@@ -3,6 +3,8 @@ package com.escodro.alkaa.di
 import com.escodro.alkaa.presentation.MainViewModel
 import com.escodro.alkaa.presentation.mapper.AppThemeOptionsMapper
 import com.escodro.core.extension.getAlarmManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -12,6 +14,8 @@ import org.koin.dsl.module
  */
 val appModule = module {
     factory { androidContext().getAlarmManager() }
+
+    factory { CoroutineScope(SupervisorJob()) }
 
     viewModel { MainViewModel(get(), get()) }
 

--- a/data/local/src/main/java/com/escodro/local/di/LocalModule.kt
+++ b/data/local/src/main/java/com/escodro/local/di/LocalModule.kt
@@ -34,6 +34,6 @@ val localModule = module {
     factory { TaskWithCategoryMapper(get(), get()) }
 
     // Providers
-    single { DatabaseProvider(get()) }
+    single { DatabaseProvider(get(), get()) }
     single { DaoProvider(get()) }
 }

--- a/data/local/src/main/java/com/escodro/local/provider/DaoProvider.kt
+++ b/data/local/src/main/java/com/escodro/local/provider/DaoProvider.kt
@@ -7,7 +7,7 @@ import com.escodro.local.dao.TaskWithCategoryDao
 /**
  * Repository with the database [androidx.room.Dao]s.
  */
-class DaoProvider(private val database: DatabaseProvider) {
+internal class DaoProvider(private val database: DatabaseProvider) {
 
     /**
      * Gets the [TaskDao].

--- a/data/local/src/main/java/com/escodro/local/provider/DatabaseProvider.kt
+++ b/data/local/src/main/java/com/escodro/local/provider/DatabaseProvider.kt
@@ -11,13 +11,16 @@ import com.escodro.local.migration.MIGRATION_1_2
 import com.escodro.local.migration.MIGRATION_2_3
 import com.escodro.local.migration.MIGRATION_3_4
 import com.escodro.local.model.Category
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
  * Repository with the [Room] database.
  */
-class DatabaseProvider(private val context: Context) {
+internal class DatabaseProvider(
+    private val context: Context,
+    private val coroutineScope: CoroutineScope
+) {
 
     private var database: TaskDatabase? = null
 
@@ -37,12 +40,11 @@ class DatabaseProvider(private val context: Context) {
             .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
 
-    @Suppress("GlobalCoroutineUsage")
     private fun onCreateDatabase() =
         object : RoomDatabase.Callback() {
             override fun onCreate(db: SupportSQLiteDatabase) {
                 super.onCreate(db)
-                GlobalScope.launch {
+                coroutineScope.launch {
                     database?.categoryDao()?.insertCategory(getDefaultCategoryList())
                 }
             }

--- a/features/alarm/src/main/java/com/escodro/alarm/TaskReceiver.kt
+++ b/features/alarm/src/main/java/com/escodro/alarm/TaskReceiver.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.alarm.RescheduleFutureAlarms
 import com.escodro.domain.usecase.alarm.ShowAlarm
 import com.escodro.domain.usecase.alarm.SnoozeAlarm
 import com.escodro.domain.usecase.task.CompleteTask
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import logcat.logcat
@@ -20,6 +20,8 @@ import org.koin.core.component.inject
  */
 internal class TaskReceiver : BroadcastReceiver(), KoinComponent {
 
+    private val coroutineScope: CoroutineScope by inject()
+
     private val completeTaskUseCase: CompleteTask by inject()
 
     private val showAlarmUseCase: ShowAlarm by inject()
@@ -28,11 +30,10 @@ internal class TaskReceiver : BroadcastReceiver(), KoinComponent {
 
     private val rescheduleUseCase: RescheduleFutureAlarms by inject()
 
-    @Suppress("GlobalCoroutineUsage")
     override fun onReceive(context: Context?, intent: Intent?) {
         logcat { "onReceive() - intent ${intent?.action}" }
 
-        GlobalScope.launch {
+        coroutineScope.launch {
             handleIntent(intent)
         }
     }


### PR DESCRIPTION
Instead of using GlobalScope, now Alkaa was updated to use an app based
CoroutineScope for more flexibility and control.