### PR TITLE
 🐞 Fix BadParcelableException

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,4 +25,4 @@
     public static ** valueOf(java.lang.String);
 }
 
--keepnames class * implements android.os.Parcelable
+-keepnames class * implements android.os.Parcelable*

--- a/features/category-api/proguard-rules.pro
+++ b/features/category-api/proguard-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keepnames class * implements android.os.Parcelable
+-keepnames class * implements android.os.Parcelable*

--- a/features/category/proguard-rules.pro
+++ b/features/category/proguard-rules.pro
@@ -25,4 +25,4 @@
     public static ** valueOf(java.lang.String);
 }
 
--keepnames class * implements android.os.Parcelable
+-keepnames class * implements android.os.Parcelable*

--- a/features/task/proguard-rules.pro
+++ b/features/task/proguard-rules.pro
@@ -25,4 +25,4 @@
     public static ** valueOf(java.lang.String);
 }
 
--keepnames class * implements android.os.Parcelable
+-keepnames class * implements android.os.Parcelable*


### PR DESCRIPTION
[issue] Even after adding the rules for Parcelable on ProGuard Rules,
the BadParcelableException was reported in the Google Play. It seems
that it may be related to the Parcelable Creator.

[solution] Add the `*` for keep the names for any Parcelable reference
in the code, even the static CREATOR