### PR TITLE
Update libraries

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
+++ b/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
@@ -43,13 +43,13 @@ fun NavGraph(startDestination: String = Destinations.Home) {
         composable(
             route = Destinations.Home,
             deepLinks = listOf(navDeepLink { uriPattern = DestinationDeepLink.HomePattern }),
-            enterTransition = { _, _ ->
+            enterTransition = {
                 slideIntoContainer(
                     AnimatedContentScope.SlideDirection.Right,
                     animationSpec = tween(700)
                 )
             },
-            exitTransition = { _, _ ->
+            exitTransition = {
                 slideOutOfContainer(
                     AnimatedContentScope.SlideDirection.Left,
                     animationSpec = tween(700)
@@ -67,13 +67,13 @@ fun NavGraph(startDestination: String = Destinations.Home) {
             route = "${Destinations.TaskDetail}/{${DestinationArgs.TaskId}}",
             arguments = listOf(navArgument(DestinationArgs.TaskId) { type = NavType.LongType }),
             deepLinks = listOf(navDeepLink { uriPattern = DestinationDeepLink.TaskDetailPattern }),
-            enterTransition = { _, _ ->
+            enterTransition = {
                 slideIntoContainer(
                     AnimatedContentScope.SlideDirection.Left,
                     animationSpec = tween(700)
                 )
             },
-            exitTransition = { _, _ ->
+            exitTransition = {
                 slideOutOfContainer(
                     AnimatedContentScope.SlideDirection.Right,
                     animationSpec = tween(700)
@@ -89,13 +89,13 @@ fun NavGraph(startDestination: String = Destinations.Home) {
 
         composable(
             route = Destinations.About,
-            enterTransition = { _, _ ->
+            enterTransition = {
                 slideIntoContainer(
                     AnimatedContentScope.SlideDirection.Left,
                     animationSpec = tween(700)
                 )
             },
-            exitTransition = { _, _ ->
+            exitTransition = {
                 slideOutOfContainer(
                     AnimatedContentScope.SlideDirection.Right,
                     animationSpec = tween(700)

--- a/data/local/src/test/java/com/escodro/local/datasource/SearchLocalDataSourceTest.kt
+++ b/data/local/src/test/java/com/escodro/local/datasource/SearchLocalDataSourceTest.kt
@@ -5,11 +5,13 @@ import com.escodro.local.provider.DaoProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class SearchLocalDataSourceTest {
 
     private val mockDaoProvider = mockk<DaoProvider>(relaxed = true)
@@ -24,7 +26,7 @@ internal class SearchLocalDataSourceTest {
     }
 
     @Test
-    fun `check if the query is enclosed with percent char`() = runBlockingTest {
+    fun `check if the query is enclosed with percent char`() = runTest {
         val query = "name"
         dataSource.findTaskByName(query)
         coVerify { mockDaoProvider.getTaskWithCategoryDao().findTaskByName("%$query%") }

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/CancelAlarmTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/CancelAlarmTest.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -29,14 +29,14 @@ class CancelAlarmTest {
     private val getTaskUseCase = LoadTaskImpl(taskRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
         glanceInteractor.clean()
     }
 
     @Test
-    fun `test if the alarm is canceled`() = runBlockingTest {
+    fun `test if the alarm is canceled`() = runTest {
         val task = Task(id = 11, title = "reminder!")
         addTaskUseCase(task)
         cancelAlarmUseCase(task.id)
@@ -45,7 +45,7 @@ class CancelAlarmTest {
     }
 
     @Test
-    fun `test if alarm is removed from task`() = runBlockingTest {
+    fun `test if alarm is removed from task`() = runTest {
         val task = Task(id = 66, title = "tik tok on the clock")
         addTaskUseCase(task)
         cancelAlarmUseCase(task.id)

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/RescheduleFutureAlarmsTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/RescheduleFutureAlarmsTest.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.fake.GlanceInteractorFake
 import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -39,13 +39,13 @@ internal class RescheduleFutureAlarmsTest {
         )
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
     }
 
     @Test
-    fun `test if future alarms are rescheduled`() = runBlockingTest {
+    fun `test if future alarms are rescheduled`() = runTest {
         val futureCalendar =
             calendarProvider.getCurrentCalendar().apply { add(Calendar.DAY_OF_MONTH, 15) }
         val task1 = Task(id = 1, title = "Task 1", dueDate = futureCalendar)
@@ -66,7 +66,7 @@ internal class RescheduleFutureAlarmsTest {
     }
 
     @Test
-    fun `test if completed tasks are not rescheduled`() = runBlockingTest {
+    fun `test if completed tasks are not rescheduled`() = runTest {
         val futureCalendar =
             calendarProvider.getCurrentCalendar().apply { add(Calendar.DAY_OF_MONTH, 15) }
         val task1 = Task(id = 1, completed = true, title = "Task 1", dueDate = futureCalendar)
@@ -87,7 +87,7 @@ internal class RescheduleFutureAlarmsTest {
     }
 
     @Test
-    fun `test if uncompleted tasks on the past are ignored`() = runBlockingTest {
+    fun `test if uncompleted tasks on the past are ignored`() = runTest {
         val pastCalendar = Calendar.getInstance().apply {
             time = calendarProvider.getCurrentCalendar().time
             add(Calendar.DAY_OF_MONTH, -15)
@@ -115,7 +115,7 @@ internal class RescheduleFutureAlarmsTest {
     }
 
     @Test
-    fun `test if missed repeating alarms are rescheduled`() = runBlockingTest {
+    fun `test if missed repeating alarms are rescheduled`() = runTest {
         val pastCalendar =
             calendarProvider.getCurrentCalendar().apply { add(Calendar.DAY_OF_MONTH, -1) }
         val task = Task(

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleAlarmTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleAlarmTest.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -30,13 +30,13 @@ internal class ScheduleAlarmTest {
     private val scheduleAlarmUseCase = ScheduleAlarmImpl(taskRepository, alarmInteractor)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
     }
 
     @Test
-    fun `test if alarm is scheduled`() = runBlockingTest {
+    fun `test if alarm is scheduled`() = runTest {
         val task = Task(id = 1, title = "I need a alarm here")
         val alarm = Calendar.getInstance()
         addTaskUseCase(task)

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleNextAlarmTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/ScheduleNextAlarmTest.kt
@@ -9,8 +9,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -37,43 +36,43 @@ internal class ScheduleNextAlarmTest {
     private val baseTask = Task(1, title = "alarm task")
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if fails if not repeating`() = runBlockingTest {
+    fun `test if fails if not repeating`() = runTest {
         val task = baseTask.copy(isRepeating = false)
         scheduleNextAlarmUseCase(task)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if fails if not repeating with valid due date`() = runBlockingTest {
+    fun `test if fails if not repeating with valid due date`() = runTest {
         val task = baseTask.copy(isRepeating = false, dueDate = Calendar.getInstance())
         scheduleNextAlarmUseCase(task)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if fails if no due date`() = runBlocking {
+    fun `test if fails if no due date`() = runTest {
         val task = baseTask.copy(dueDate = null)
         scheduleNextAlarmUseCase(task)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if fails if no due date but it is repeating`() = runBlocking {
+    fun `test if fails if no due date but it is repeating`() = runTest {
         val task = baseTask.copy(isRepeating = true, dueDate = null)
         scheduleNextAlarmUseCase(task)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if fails if no alarm interval`() = runBlocking {
+    fun `test if fails if no alarm interval`() = runTest {
         val task = baseTask.copy(dueDate = null, alarmInterval = null)
         scheduleNextAlarmUseCase(task)
     }
 
     @Test
-    fun `test if alarm is updated to next hour`() = runBlockingTest {
+    fun `test if alarm is updated to next hour`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = baseTask.copy(
             dueDate = calendar,
@@ -95,7 +94,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if alarm is updated to next day`() = runBlockingTest {
+    fun `test if alarm is updated to next day`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = baseTask.copy(
             dueDate = calendar,
@@ -117,7 +116,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if alarm is updated to next week`() = runBlockingTest {
+    fun `test if alarm is updated to next week`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = baseTask.copy(
             dueDate = calendar,
@@ -139,7 +138,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if alarm is updated to next month`() = runBlockingTest {
+    fun `test if alarm is updated to next month`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = baseTask.copy(
             dueDate = calendar,
@@ -161,7 +160,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if alarm is updated to next year`() = runBlockingTest {
+    fun `test if alarm is updated to next year`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = baseTask.copy(
             dueDate = calendar,
@@ -183,7 +182,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if new alarm is scheduled`() = runBlockingTest {
+    fun `test if new alarm is scheduled`() = runTest {
         val task = baseTask.copy(
             isRepeating = true,
             dueDate = Calendar.getInstance(),
@@ -197,7 +196,7 @@ internal class ScheduleNextAlarmTest {
     }
 
     @Test
-    fun `test if missed repeating alarm is set on future`() = runBlockingTest {
+    fun `test if missed repeating alarm is set on future`() = runTest {
         val pastCalendar = Calendar.getInstance().apply { add(Calendar.HOUR, -5) }
         val task = baseTask.copy(
             dueDate = pastCalendar,

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/ShowAlarmTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/ShowAlarmTest.kt
@@ -9,7 +9,7 @@ import com.escodro.domain.usecase.fake.NotificationInteractorFake
 import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -36,14 +36,14 @@ internal class ShowAlarmTest {
         ShowAlarm(taskRepository, notificationInteractor, scheduleNextAlarmUseCase)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
         notificationInteractor.clear()
     }
 
     @Test
-    fun `test if alarm is shown when task is not yet completed`() = runBlockingTest {
+    fun `test if alarm is shown when task is not yet completed`() = runTest {
         val task = Task(1, title = "should show", completed = false)
         addTaskUseCase(task)
 
@@ -53,7 +53,7 @@ internal class ShowAlarmTest {
     }
 
     @Test
-    fun `test if alarm is ignored when task is already completed`() = runBlockingTest {
+    fun `test if alarm is ignored when task is already completed`() = runTest {
         val task = Task(2, title = "should not show", completed = true)
         addTaskUseCase(task)
 
@@ -63,7 +63,7 @@ internal class ShowAlarmTest {
     }
 
     @Test
-    fun `test if next alarm is scheduled when task is repeating`() = runBlockingTest {
+    fun `test if next alarm is scheduled when task is repeating`() = runTest {
         val calendar = calendarProvider.getCurrentCalendar()
         val task = Task(
             3,
@@ -80,7 +80,7 @@ internal class ShowAlarmTest {
     }
 
     @Test
-    fun `test if next alarm is not scheduled when task is not repeating`() = runBlockingTest {
+    fun `test if next alarm is not scheduled when task is not repeating`() = runTest {
         val task = Task(4, title = "should not repeat", isRepeating = false)
         addTaskUseCase(task)
 
@@ -90,7 +90,7 @@ internal class ShowAlarmTest {
     }
 
     @Test
-    fun `test if next alarm is not scheduled when task is completed`() = runBlockingTest {
+    fun `test if next alarm is not scheduled when task is completed`() = runTest {
         val task = Task(4, title = "it is already completed", isRepeating = true, completed = true)
         addTaskUseCase(task)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/SnoozeAlarmTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/SnoozeAlarmTest.kt
@@ -5,7 +5,7 @@ import com.escodro.domain.usecase.fake.AlarmInteractorFake
 import com.escodro.domain.usecase.fake.CalendarProviderFake
 import com.escodro.domain.usecase.fake.NotificationInteractorFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -26,13 +26,13 @@ internal class SnoozeAlarmTest {
     private val baseTask = Task(id = 2345L, title = "it's time")
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         alarmInteractor.clear()
         notificationInteractor.clear()
     }
 
     @Test
-    fun `test if task is snoozed`() = runBlockingTest {
+    fun `test if task is snoozed`() = runTest {
         val snoozeTime = 15
 
         snoozeAlarmUseCase(baseTask.id, snoozeTime)
@@ -46,7 +46,7 @@ internal class SnoozeAlarmTest {
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `test if error is shown when snoozing with negative number`() = runBlockingTest {
+    fun `test if error is shown when snoozing with negative number`() = runTest {
         snoozeAlarmUseCase(baseTask.id, -15)
     }
 

--- a/domain/src/test/java/com/escodro/domain/usecase/alarm/UpdateTaskAsRepeatingTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/alarm/UpdateTaskAsRepeatingTest.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -27,12 +27,12 @@ internal class UpdateTaskAsRepeatingTest {
     private val scheduleRepeatingUseCase = UpdateTaskAsRepeatingImpl(taskRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
     }
 
     @Test
-    fun `test if task is updated with new interval`() = runBlockingTest {
+    fun `test if task is updated with new interval`() = runTest {
         val task = Task(id = 984L, title = "I'll be there for you")
         addTaskUseCase(task)
         val interval = AlarmInterval.WEEKLY
@@ -46,22 +46,21 @@ internal class UpdateTaskAsRepeatingTest {
     }
 
     @Test
-    fun `test if repeating state is cleared when update alarm interval to never`() =
-        runBlockingTest {
-            val task = Task(
-                id = 984L,
-                title = "nanana",
-                alarmInterval = AlarmInterval.YEARLY,
-                isRepeating = true
-            )
+    fun `test if repeating state is cleared when update alarm interval to never`() = runTest {
+        val task = Task(
+            id = 984L,
+            title = "nanana",
+            alarmInterval = AlarmInterval.YEARLY,
+            isRepeating = true
+        )
 
-            addTaskUseCase(task)
+        addTaskUseCase(task)
 
-            scheduleRepeatingUseCase(task.id, null)
+        scheduleRepeatingUseCase(task.id, null)
 
-            val result = getTaskUseCase(task.id)
-            require(result != null)
-            Assert.assertEquals(null, result.alarmInterval)
-            Assert.assertFalse(result.isRepeating)
-        }
+        val result = getTaskUseCase(task.id)
+        require(result != null)
+        Assert.assertEquals(null, result.alarmInterval)
+        Assert.assertFalse(result.isRepeating)
+    }
 }

--- a/domain/src/test/java/com/escodro/domain/usecase/category/AddCategoryTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/category/AddCategoryTest.kt
@@ -6,7 +6,7 @@ import com.escodro.domain.usecase.category.implementation.LoadAllCategoriesImpl
 import com.escodro.domain.usecase.fake.CategoryRepositoryFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -23,12 +23,12 @@ internal class AddCategoryTest {
     private val loadAllCategoriesUseCase = LoadAllCategoriesImpl(categoryRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         categoryRepository.cleanTable()
     }
 
     @Test
-    fun `test if category is correctly added`() = runBlockingTest {
+    fun `test if category is correctly added`() = runTest {
         val category = Category(id = 22, name = "shopping list", color = "#122100")
         addCategoryUseCase(category)
 
@@ -37,7 +37,7 @@ internal class AddCategoryTest {
     }
 
     @Test
-    fun `test if category with empty title is not added`() = runBlockingTest {
+    fun `test if category with empty title is not added`() = runTest {
         val category = Category(id = 44, name = "   ", color = "#876782")
         addCategoryUseCase(category)
 
@@ -46,7 +46,7 @@ internal class AddCategoryTest {
     }
 
     @Test
-    fun `test if all category are added`() = runBlockingTest {
+    fun `test if all category are added`() = runTest {
         val assertList = mutableListOf<Category>()
         for (iterator in 1..100) {
             val category = Category(id = iterator.toLong(), name = "$iterator", color = "#5567FA")

--- a/domain/src/test/java/com/escodro/domain/usecase/category/DeleteCategoryTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/category/DeleteCategoryTest.kt
@@ -5,7 +5,7 @@ import com.escodro.domain.usecase.category.implementation.AddCategoryImpl
 import com.escodro.domain.usecase.category.implementation.DeleteCategoryImpl
 import com.escodro.domain.usecase.fake.CategoryRepositoryFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -22,12 +22,12 @@ class DeleteCategoryTest {
     private val loadCategory = LoadCategory(categoryRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         categoryRepository.cleanTable()
     }
 
     @Test
-    fun `test if category is deleted`() = runBlockingTest {
+    fun `test if category is deleted`() = runTest {
         val category = Category(id = 13, name = "books to read", color = "#FFAA00")
         addCategory(category)
         deleteCategory(category)

--- a/domain/src/test/java/com/escodro/domain/usecase/category/UpdateCategoryTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/category/UpdateCategoryTest.kt
@@ -5,7 +5,7 @@ import com.escodro.domain.usecase.category.implementation.AddCategoryImpl
 import com.escodro.domain.usecase.category.implementation.UpdateCategoryImpl
 import com.escodro.domain.usecase.fake.CategoryRepositoryFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -22,12 +22,12 @@ internal class UpdateCategoryTest {
     private val updateCategoryUseCase = UpdateCategoryImpl(categoryRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         categoryRepository.cleanTable()
     }
 
     @Test
-    fun `test if category is updated`() = runBlockingTest {
+    fun `test if category is updated`() = runTest {
         val category = Category(id = 24, name = "toys", color = "#04206F")
         addCategoryUseCase(category)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/preferences/AppThemeTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/preferences/AppThemeTest.kt
@@ -4,7 +4,7 @@ import com.escodro.domain.model.AppThemeOptions
 import com.escodro.domain.usecase.fake.PreferencesRepositoryFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -18,7 +18,7 @@ internal class AppThemeTest {
     private val loadAppTheme = LoadAppTheme(preferencesRepository)
 
     @Test
-    fun `test if theme is updated`() = runBlockingTest {
+    fun `test if theme is updated`() = runTest {
         updateAppTheme(AppThemeOptions.DARK)
 
         val result = loadAppTheme().first()
@@ -27,7 +27,7 @@ internal class AppThemeTest {
     }
 
     @Test
-    fun `test if last updated theme is the one valid`() = runBlockingTest {
+    fun `test if last updated theme is the one valid`() = runTest {
         updateAppTheme(AppThemeOptions.LIGHT)
         updateAppTheme(AppThemeOptions.SYSTEM)
         updateAppTheme(AppThemeOptions.DARK)

--- a/domain/src/test/java/com/escodro/domain/usecase/search/SearchTasksTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/search/SearchTasksTest.kt
@@ -6,7 +6,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.search.implementation.SearchTasksByNameImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -21,7 +21,7 @@ internal class SearchTasksTest {
     private val searchTaskUseCase = SearchTasksByNameImpl(searchRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         val task1 = Task(1, title = "Buy milk", completed = false)
         val task2 = Task(2, title = "Schedule meeting", completed = true)
         val task3 = Task(3, title = "Angela's birthday", completed = true)
@@ -31,7 +31,7 @@ internal class SearchTasksTest {
     }
 
     @Test
-    fun `test if search returns correct tasks`() = runBlockingTest {
+    fun `test if search returns correct tasks`() = runTest {
         val query = "birthday"
         val taskList = searchTaskUseCase(query).first()
 
@@ -43,13 +43,13 @@ internal class SearchTasksTest {
     }
 
     @Test
-    fun `test if return list is empty when query is not found`() = runBlockingTest {
+    fun `test if return list is empty when query is not found`() = runTest {
         val taskList = searchTaskUseCase("pineapple")
         Assert.assertEquals(0, taskList.first().size)
     }
 
     @Test
-    fun `test if all tasks are returned when empty query is passed`() = runBlockingTest {
+    fun `test if all tasks are returned when empty query is passed`() = runTest {
         val taskList = searchTaskUseCase("")
         Assert.assertEquals(4, taskList.first().size)
     }

--- a/domain/src/test/java/com/escodro/domain/usecase/task/AddTaskTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/task/AddTaskTest.kt
@@ -6,7 +6,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -23,13 +23,13 @@ internal class AddTaskTest {
     private val getTaskUseCase = LoadTaskImpl(taskRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         glanceInteractor.clean()
     }
 
     @Test
-    fun `test if task is correctly added`() = runBlockingTest {
+    fun `test if task is correctly added`() = runTest {
         val task = Task(id = 15, title = "this title", description = "this desc")
         addTaskUseCase(task)
 
@@ -40,7 +40,7 @@ internal class AddTaskTest {
     }
 
     @Test
-    fun `test if task with empty title is not added`() = runBlockingTest {
+    fun `test if task with empty title is not added`() = runTest {
         val task = Task(id = 15, title = " ", description = "this desc")
         addTaskUseCase(task)
 
@@ -50,7 +50,7 @@ internal class AddTaskTest {
     }
 
     @Test
-    fun `test if the glance was notified`() = runBlockingTest {
+    fun `test if the glance was notified`() = runTest {
         val task = Task(id = 15, title = "this title", description = "this desc")
         addTaskUseCase(task)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/task/CompleteTaskTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/task/CompleteTaskTest.kt
@@ -10,7 +10,7 @@ import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import com.escodro.domain.usecase.task.implementation.UpdateTaskStatusImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -45,7 +45,7 @@ internal class CompleteTaskTest {
     private val getTaskUseCase = LoadTaskImpl(taskRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
         glanceInteractor.clean()
@@ -53,7 +53,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if a task is updated as completed`() = runBlockingTest {
+    fun `test if a task is updated as completed`() = runTest {
         val task = Task(id = 18, title = "buy soy milk", completed = false)
         addTaskUseCase(task)
         completeTaskUseCase(task)
@@ -65,7 +65,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if a task is updated as completed by id`() = runBlockingTest {
+    fun `test if a task is updated as completed by id`() = runTest {
         val task = Task(id = 17, title = "change smartphone", completed = false)
         addTaskUseCase(task)
         completeTaskUseCase(task.id)
@@ -77,7 +77,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if a task is updated as uncompleted`() = runBlockingTest {
+    fun `test if a task is updated as uncompleted`() = runTest {
         val task = Task(id = 18, title = "buy soy milk", completed = false)
         addTaskUseCase(task)
         uncompleteTaskUseCase(task)
@@ -89,7 +89,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if the completed status is inverted`() = runBlockingTest {
+    fun `test if the completed status is inverted`() = runTest {
         val task1 = Task(id = 99, title = "watch tech talk", completed = true)
         val task2 = Task(id = 88, title = "write paper", completed = false)
 
@@ -109,7 +109,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if the alarm is canceled when the task is completed`() = runBlockingTest {
+    fun `test if the alarm is canceled when the task is completed`() = runTest {
         val task = Task(id = 19, title = "sato's meeting", completed = false)
         addTaskUseCase(task)
         completeTaskUseCase(task)
@@ -118,7 +118,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if the notification is dismissed when the task is completed`() = runBlockingTest {
+    fun `test if the notification is dismissed when the task is completed`() = runTest {
         val task = Task(id = 20, title = "scrum master dog", completed = false)
         addTaskUseCase(task)
         completeTaskUseCase(task)
@@ -127,7 +127,7 @@ internal class CompleteTaskTest {
     }
 
     @Test
-    fun `test if the glance was notified`() = runBlockingTest {
+    fun `test if the glance was notified`() = runTest {
         val task = Task(id = 15, title = "this title", description = "this desc")
         addTaskUseCase(task)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/task/DeleteTaskTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/task/DeleteTaskTest.kt
@@ -7,7 +7,7 @@ import com.escodro.domain.usecase.fake.TaskRepositoryFake
 import com.escodro.domain.usecase.task.implementation.AddTaskImpl
 import com.escodro.domain.usecase.task.implementation.LoadTaskImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -28,14 +28,14 @@ internal class DeleteTaskTest {
     private val addTaskUseCase = AddTaskImpl(taskRepository, glanceInteractor)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         taskRepository.cleanTable()
         alarmInteractor.clear()
         glanceInteractor.clean()
     }
 
     @Test
-    fun `test if task is deleted`() = runBlockingTest {
+    fun `test if task is deleted`() = runTest {
         val task = Task(id = 18, title = "coffee time")
         addTaskUseCase(task)
         deleteTaskUseCase(task)
@@ -46,7 +46,7 @@ internal class DeleteTaskTest {
     }
 
     @Test
-    fun `test if the alarm is canceled when the task is completed`() = runBlockingTest {
+    fun `test if the alarm is canceled when the task is completed`() = runTest {
         val task = Task(id = 19, title = "SOLID basics")
         addTaskUseCase(task)
         deleteTaskUseCase(task)
@@ -55,7 +55,7 @@ internal class DeleteTaskTest {
     }
 
     @Test
-    fun `test if the glance was notified`() = runBlockingTest {
+    fun `test if the glance was notified`() = runTest {
         val task = Task(id = 15, title = "this title", description = "this desc")
         addTaskUseCase(task)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/task/UpdateTaskTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/task/UpdateTaskTest.kt
@@ -10,7 +10,7 @@ import com.escodro.domain.usecase.task.implementation.UpdateTaskDescriptionImpl
 import com.escodro.domain.usecase.task.implementation.UpdateTaskImpl
 import com.escodro.domain.usecase.task.implementation.UpdateTaskTitleImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -43,7 +43,7 @@ internal class UpdateTaskTest {
     }
 
     @Test
-    fun `test if task is updated`() = runBlockingTest {
+    fun `test if task is updated`() = runTest {
         val task = Task(id = 15, title = "its funny", description = "indeed")
         addTaskUseCase(task)
 
@@ -55,7 +55,7 @@ internal class UpdateTaskTest {
     }
 
     @Test
-    fun `test if task title is updated`() = runBlockingTest {
+    fun `test if task title is updated`() = runTest {
         val task = Task(id = 15, title = "its funny", description = "indeed")
         addTaskUseCase(task)
 
@@ -67,7 +67,7 @@ internal class UpdateTaskTest {
     }
 
     @Test
-    fun `test if task description is updated`() = runBlockingTest {
+    fun `test if task description is updated`() = runTest {
         val task = Task(id = 15, title = "its funny", description = "indeed")
         addTaskUseCase(task)
 
@@ -79,7 +79,7 @@ internal class UpdateTaskTest {
     }
 
     @Test
-    fun `test if task category is updated`() = runBlockingTest {
+    fun `test if task category is updated`() = runTest {
         val task = Task(id = 15, title = "its funny", categoryId = null)
         addTaskUseCase(task)
 
@@ -91,7 +91,7 @@ internal class UpdateTaskTest {
     }
 
     @Test
-    fun `test if the glance was notified`() = runBlockingTest {
+    fun `test if the glance was notified`() = runTest {
         val task = Task(id = 15, title = "this title", description = "this desc")
         addTaskUseCase(task)
 

--- a/domain/src/test/java/com/escodro/domain/usecase/taskwithcategory/LoadTasksTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/taskwithcategory/LoadTasksTest.kt
@@ -8,7 +8,7 @@ import com.escodro.domain.usecase.fake.TaskWithCategoryRepositoryFake
 import com.escodro.domain.usecase.taskwithcategory.implementation.LoadUncompletedTasksImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -29,7 +29,7 @@ internal class LoadTasksTest {
     private val loadUncompletedTasksUseCase = LoadUncompletedTasksImpl(taskWithCategoryRepository)
 
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         val category1 = Category(id = 1, name = "cat1", color = "#FFFFFF")
         val category2 = Category(id = 2, name = "cat2", color = "#000000")
         categoryRepository.insertCategory(listOf(category1, category2))
@@ -43,13 +43,13 @@ internal class LoadTasksTest {
     }
 
     @After
-    fun tearDown() = runBlockingTest {
+    fun tearDown() = runTest {
         taskRepository.cleanTable()
         categoryRepository.cleanTable()
     }
 
     @Test
-    fun `test if completed tasks are filtered`() = runBlockingTest {
+    fun `test if completed tasks are filtered`() = runTest {
         val completedTasks = loadCompletedTasksUseCase().first()
 
         Assert.assertEquals(2, completedTasks.size)
@@ -59,7 +59,7 @@ internal class LoadTasksTest {
     }
 
     @Test
-    fun `test if uncompleted tasks are filtered`() = runBlockingTest {
+    fun `test if uncompleted tasks are filtered`() = runTest {
         val uncompletedTasks = loadUncompletedTasksUseCase().first()
 
         Assert.assertEquals(2, uncompletedTasks.size)
@@ -69,7 +69,7 @@ internal class LoadTasksTest {
     }
 
     @Test
-    fun `test if uncompleted tasks are filtered by category`() = runBlockingTest {
+    fun `test if uncompleted tasks are filtered by category`() = runTest {
         val uncompletedTasksByCategory = loadUncompletedTasksUseCase(2L).first()
 
         Assert.assertEquals(1, uncompletedTasksByCategory.size)

--- a/domain/src/test/java/com/escodro/domain/usecase/tracker/LoadCompletedTasksByPeriodTest.kt
+++ b/domain/src/test/java/com/escodro/domain/usecase/tracker/LoadCompletedTasksByPeriodTest.kt
@@ -9,7 +9,7 @@ import com.escodro.domain.usecase.fake.TaskWithCategoryRepositoryFake
 import com.escodro.domain.usecase.tracker.implementation.LoadCompletedTasksByPeriodImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 import java.util.Calendar
@@ -27,7 +27,7 @@ internal class LoadCompletedTasksByPeriodTest {
     private val loadTrackerUseCase = LoadCompletedTasksByPeriodImpl(taskWithCategoryRepository)
 
     @Test
-    fun `test if completed tasks are returned in group`() = runBlockingTest {
+    fun `test if completed tasks are returned in group`() = runTest {
         val category1 = Category(1, "Category A", "#FFFFFF")
         val category2 = Category(2, "Category B", "#CCCCCC")
         val category3 = Category(3, "Category C", "#AAAAAA")
@@ -58,7 +58,7 @@ internal class LoadCompletedTasksByPeriodTest {
     }
 
     @Test
-    fun `test if only completed tasks are returned`() = runBlockingTest {
+    fun `test if only completed tasks are returned`() = runTest {
         val category1 = Category(1, "Category A", "#FFFFFF")
         val category2 = Category(2, "Category B", "#CCCCCC")
         val categoryList = listOf(category1, category2)
@@ -83,7 +83,7 @@ internal class LoadCompletedTasksByPeriodTest {
     }
 
     @Test
-    fun `test if completed tasks without category are considered`() = runBlockingTest {
+    fun `test if completed tasks without category are considered`() = runTest {
         val calendarIn = Calendar.getInstance().apply { add(Calendar.DAY_OF_MONTH, -10) }
         val task = Task(3, completed = true, title = "Lonely", completedDate = calendarIn)
         taskRepository.insertTask(task)

--- a/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModelTest.kt
+++ b/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModelTest.kt
@@ -5,10 +5,14 @@ import com.escodro.category.fake.AddCategoryFake
 import com.escodro.category.mapper.CategoryMapper
 import com.escodro.categoryapi.model.Category
 import com.escodro.core.extension.toStringColor
+import com.escodro.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class CategoryAddViewModelTest {
 
     private val addCategory = AddCategoryFake()
@@ -16,6 +20,9 @@ internal class CategoryAddViewModelTest {
     private val categoryMapper = CategoryMapper()
 
     private val viewModel = CategoryAddViewModel(addCategory, categoryMapper)
+
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
 
     @Before
     fun setup() {

--- a/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModelTest.kt
+++ b/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModelTest.kt
@@ -5,10 +5,14 @@ import com.escodro.category.fake.DeleteCategoryFake
 import com.escodro.category.fake.UpdateCategoryFake
 import com.escodro.category.mapper.CategoryMapper
 import com.escodro.categoryapi.model.Category
+import com.escodro.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class CategoryEditViewModelTest {
 
     private val updateCategory = UpdateCategoryFake()
@@ -18,6 +22,9 @@ internal class CategoryEditViewModelTest {
     private val mapper = CategoryMapper()
 
     private val viewModel = CategoryEditViewModel(updateCategory, deleteCategory, mapper)
+
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
 
     @Before
     fun setup() {

--- a/features/category/src/test/java/com/escodro/category/presentation/list/CategoryListViewModelTest.kt
+++ b/features/category/src/test/java/com/escodro/category/presentation/list/CategoryListViewModelTest.kt
@@ -7,7 +7,7 @@ import com.escodro.categoryapi.presentation.CategoryState
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -26,7 +26,7 @@ internal class CategoryListViewModelTest {
 
     @Test
     fun `test if when there is categories created than it returns the success state with them`() =
-        runBlockingTest {
+        runTest {
 
             // Given the viewModel is called to load the categories
             loadAllCategories.categoriesToBeReturned = FAKE_DOMAIN_CATEGORY_LIST
@@ -43,7 +43,7 @@ internal class CategoryListViewModelTest {
 
     @Test
     fun `test if when there is no categories created than it returns the success state with empty list`() =
-        runBlockingTest {
+        runTest {
             // Given the viewModel is called to load the categories
             loadAllCategories.categoriesToBeReturned = listOf()
             val flow = viewModel.loadCategories()

--- a/features/search/src/test/java/com/escodro/search/presentation/SearchViewModelTest.kt
+++ b/features/search/src/test/java/com/escodro/search/presentation/SearchViewModelTest.kt
@@ -5,7 +5,8 @@ import com.escodro.search.mapper.TaskSearchMapper
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -23,35 +24,33 @@ internal class SearchViewModelTest {
     private val viewModel = SearchViewModel(searchTasksByName, mockMapper)
 
     @Test
-    fun `check if loaded state is returned when there are tasks`() =
-        coroutinesRule.testDispatcher.runBlockingTest {
+    fun `check if loaded state is returned when there are tasks`() = runTest {
 
-            // Given the viewModel is called to search tasks
-            val numberOfValues = 10
-            searchTasksByName.returnValues(numberOfValues)
-            val flow = viewModel.findTasksByName("task name")
+        // Given the viewModel is called to search tasks
+        val numberOfValues = 10
+        searchTasksByName.returnValues(numberOfValues)
+        val flow = viewModel.findTasksByName("task name")
 
-            // When the latest event is collected
-            val state = flow.first()
+        // When the latest event is collected
+        val state = flow.first()
 
-            // Then the state contain the queried task
-            coroutinesRule.testDispatcher.advanceUntilIdle()
-            require(state is SearchViewState.Loaded)
-            Assert.assertEquals(numberOfValues, state.taskList.size)
-        }
+        // Then the state contain the queried task
+        advanceUntilIdle()
+        require(state is SearchViewState.Loaded)
+        Assert.assertEquals(numberOfValues, state.taskList.size)
+    }
 
     @Test
-    fun `check if empty state is returned when there are no tasks`() =
-        coroutinesRule.testDispatcher.runBlockingTest {
+    fun `check if empty state is returned when there are no tasks`() = runTest() {
 
-            // Given the viewModel is called to search tasks but don't match the query
-            searchTasksByName.returnValues(0)
-            val flow = viewModel.findTasksByName("bla bla")
+        // Given the viewModel is called to search tasks but don't match the query
+        searchTasksByName.returnValues(0)
+        val flow = viewModel.findTasksByName("bla bla")
 
-            // When the latest event is collected
-            val state = flow.first()
+        // When the latest event is collected
+        val state = flow.first()
 
-            // Then the state is empty
-            assert(state is SearchViewState.Empty)
-        }
+        // Then the state is empty
+        assert(state is SearchViewState.Empty)
+    }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
@@ -8,12 +8,14 @@ import com.escodro.task.presentation.fake.CancelAlarmFake
 import com.escodro.task.presentation.fake.ScheduleAlarmFake
 import com.escodro.task.presentation.fake.UpdateTaskAsRepeatingFake
 import com.escodro.test.CoroutineTestRule
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import java.util.Calendar
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class TaskAlarmViewModelTest {
 
     @get:Rule
@@ -31,7 +33,7 @@ internal class TaskAlarmViewModelTest {
         TaskAlarmViewModel(scheduleAlarm, updateTaskAsRepeating, cancelAlarm, alarmIntervalMapper)
 
     @Test
-    fun `test if alarm is set`() = runBlockingTest {
+    fun `test if alarm is set`() = runTest {
         // Given the alarm to be set
         val taskId = 123L
         val alarm = Calendar.getInstance()
@@ -45,7 +47,7 @@ internal class TaskAlarmViewModelTest {
     }
 
     @Test
-    fun `test if alarm is set as repeating`() = runBlockingTest {
+    fun `test if alarm is set as repeating`() = runTest {
         // Given the alarm to be set with interval
         val taskId = 123L
         val alarmInterval = AlarmInterval.WEEKLY
@@ -60,7 +62,7 @@ internal class TaskAlarmViewModelTest {
     }
 
     @Test
-    fun `test if alarm is removed`() = runBlockingTest {
+    fun `test if alarm is removed`() = runTest {
         // Given the alarm to be removed
         val taskId = 123L
 

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
@@ -15,7 +15,9 @@ import com.escodro.task.presentation.fake.UpdateTaskTitleFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -42,11 +44,11 @@ internal class TaskDetailViewModelTest {
         updateTaskDescription = updateDescription,
         updateTaskCategory = updateTaskCategory,
         taskMapper = taskMapper,
-        coroutineDebouncer = CoroutinesDebouncerFake(coroutineTestRule.testDispatcher)
+        coroutineDebouncer = CoroutinesDebouncerFake()
     )
 
     @Test
-    fun `test if when a task exist it returns the success state`() = runBlockingTest {
+    fun `test if when a task exist it returns the success state`() = runTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
         val flow = viewModel.loadTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
@@ -61,7 +63,7 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when a task does not exist it returns the error state`() = runBlockingTest {
+    fun `test if when a task does not exist it returns the error state`() = runTest {
         // Given the viewModel is called to load the task info
         loadTask.taskToBeReturned = null
         val flow = viewModel.loadTaskInfo(TaskId(FAKE_DOMAIN_TASK.id))
@@ -74,7 +76,7 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when the update title is called, the field is updated`() = runBlockingTest {
+    fun `test if when the update title is called, the field is updated`() = runTest {
 
         // Given the viewModel is called to load the task info
         val taskId = TaskId(FAKE_DOMAIN_TASK.id)
@@ -84,7 +86,7 @@ internal class TaskDetailViewModelTest {
         // When the title is updated
         val newTitle = "title"
         viewModel.updateTitle(taskId = taskId, title = newTitle)
-        coroutineTestRule.testDispatcher.advanceUntilIdle() /* Advance typing debounce */
+        runCurrent() /* Advance typing debounce */
 
         // Then the task will be updated with given title
         Assert.assertTrue(updateTaskTitle.isTitleUpdated(FAKE_DOMAIN_TASK.id))
@@ -93,7 +95,7 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when the update description is called, the field is updated`() = runBlockingTest {
+    fun `test if when the update description is called, the field is updated`() = runTest {
 
         // Given the viewModel is called to load the task info
         val taskId = TaskId(FAKE_DOMAIN_TASK.id)
@@ -103,7 +105,7 @@ internal class TaskDetailViewModelTest {
         // When the description is updated
         val newDescription = "description"
         viewModel.updateDescription(taskId = taskId, description = newDescription)
-        coroutineTestRule.testDispatcher.advanceUntilIdle() /* Advance typing debounce */
+        advanceUntilIdle() /* Advance typing debounce */
 
         // Then the task will be updated with given description
         Assert.assertTrue(updateDescription.isDescriptionUpdated(FAKE_DOMAIN_TASK.id))
@@ -112,7 +114,7 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when update category is called, the category is updated`() = runBlockingTest {
+    fun `test if when update category is called, the category is updated`() = runTest {
         // Given the viewModel is called to load the categories
         val taskId = TaskId(FAKE_DOMAIN_TASK.id)
         loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
@@ -129,20 +131,19 @@ internal class TaskDetailViewModelTest {
     }
 
     @Test
-    fun `test if when update category is called with null, the category is updated`() =
-        runBlockingTest {
+    fun `test if when update category is called with null, the category is updated`() = runTest {
 
-            // Given the viewModel is called to load the categories
-            val taskId = TaskId(FAKE_DOMAIN_TASK.id)
-            loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
-            viewModel.loadTaskInfo(taskId)
+        // Given the viewModel is called to load the categories
+        val taskId = TaskId(FAKE_DOMAIN_TASK.id)
+        loadTask.taskToBeReturned = FAKE_DOMAIN_TASK
+        viewModel.loadTaskInfo(taskId)
 
-            // When the category id is updated
-            viewModel.updateCategory(taskId = taskId, categoryId = CategoryId(null))
+        // When the category id is updated
+        viewModel.updateCategory(taskId = taskId, categoryId = CategoryId(null))
 
-            // Then the task will be updated with given category id
-            Assert.assertTrue(updateTaskCategory.isCategoryUpdated(taskId.value))
-            val updatedCategoryId = updateTaskCategory.getUpdatedCategory(taskId.value)
-            Assert.assertNull(updatedCategoryId)
-        }
+        // Then the task will be updated with given category id
+        Assert.assertTrue(updateTaskCategory.isCategoryUpdated(taskId.value))
+        val updatedCategoryId = updateTaskCategory.getUpdatedCategory(taskId.value)
+        Assert.assertNull(updatedCategoryId)
+    }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/fake/CoroutinesDebouncerFake.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/fake/CoroutinesDebouncerFake.kt
@@ -3,15 +3,13 @@ package com.escodro.task.presentation.fake
 import com.escodro.core.coroutines.CoroutineDebouncer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 
 @Suppress("GlobalCoroutineUsage")
-internal class CoroutinesDebouncerFake(private val testDispatcher: TestCoroutineDispatcher) :
-    CoroutineDebouncer {
+internal class CoroutinesDebouncerFake : CoroutineDebouncer {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun invoke(delay: Long, coroutineScope: CoroutineScope, function: suspend () -> Unit) {
-        testDispatcher.runBlockingTest { function() }
+        runTest { function() }
     }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
@@ -10,7 +10,7 @@ import com.escodro.task.presentation.fake.UpdateTaskStatusFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -38,7 +38,7 @@ internal class TaskListViewModelTest {
     }
 
     @Test
-    fun `test if when there are uncompleted items, they are returned`() = runBlockingTest {
+    fun `test if when there are uncompleted items, they are returned`() = runTest {
 
         // Given the use case returns the list with uncompleted tasks
         val numberOfEntries = 14
@@ -54,34 +54,32 @@ internal class TaskListViewModelTest {
     }
 
     @Test
-    fun `test if when there are no uncompleted items, a empty list is returned`() =
-        coroutinesRule.testDispatcher.runBlockingTest {
+    fun `test if when there are no uncompleted items, a empty list is returned`() = runTest {
 
-            // Given the use case returns an empty list
-            loadUncompletedTasks.clean()
-            val flow = viewModel.loadTaskList()
+        // Given the use case returns an empty list
+        loadUncompletedTasks.clean()
+        val flow = viewModel.loadTaskList()
 
-            // When the latest event is collected
-            val state = flow.first()
+        // When the latest event is collected
+        val state = flow.first()
 
-            // Then that state contains the empty list
-            Assert.assertTrue(state is TaskListViewState.Empty)
-        }
+        // Then that state contains the empty list
+        Assert.assertTrue(state is TaskListViewState.Empty)
+    }
 
     @Test
-    fun `test if when load tasks fails, the error state is returned`() =
-        coroutinesRule.testDispatcher.runBlockingTest {
+    fun `test if when load tasks fails, the error state is returned`() = runTest {
 
-            // Given the use case returns error
-            loadUncompletedTasks.throwError = true
-            val flow = viewModel.loadTaskList()
+        // Given the use case returns error
+        loadUncompletedTasks.throwError = true
+        val flow = viewModel.loadTaskList()
 
-            // When the latest event is collected
-            val state = flow.first()
+        // When the latest event is collected
+        val state = flow.first()
 
-            // Then that state contains the empty list
-            Assert.assertTrue(state is TaskListViewState.Error)
-        }
+        // Then that state contains the empty list
+        Assert.assertTrue(state is TaskListViewState.Error)
+    }
 
     @Test
     fun `test if task is updated`() {
@@ -96,7 +94,7 @@ internal class TaskListViewModelTest {
     }
 
     @Test
-    fun `test if tasks are filtered by category when parameter is passed`() = runBlockingTest {
+    fun `test if tasks are filtered by category when parameter is passed`() = runTest {
         // Given the use case returns the list with uncompleted tasks
         loadUncompletedTasks.returnDefaultValues()
         val flow = viewModel.loadTaskList(categoryId = 1)

--- a/features/tracker/src/test/java/com/escodro/tracker/TrackerViewModelTest.kt
+++ b/features/tracker/src/test/java/com/escodro/tracker/TrackerViewModelTest.kt
@@ -7,7 +7,7 @@ import com.escodro.tracker.presentation.TrackerViewModel
 import com.escodro.tracker.presentation.TrackerViewState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -28,7 +28,7 @@ internal class TrackerViewModelTest {
     }
 
     @Test
-    fun `check if show state was called`() = runBlockingTest {
+    fun `check if show state was called`() = runTest {
         // Given the use case returns the list with completed tasks by period
         loadCompletedTasksByPeriod.returnDefaultValues()
         val flow = viewModel.loadTracker()
@@ -41,7 +41,7 @@ internal class TrackerViewModelTest {
     }
 
     @Test
-    fun `check if empty state was called`() = runBlockingTest {
+    fun `check if empty state was called`() = runTest {
         // Given the use case returns an empty list with completed tasks by period
         loadCompletedTasksByPeriod.clearList()
         val flow = viewModel.loadTracker()
@@ -54,7 +54,7 @@ internal class TrackerViewModelTest {
     }
 
     @Test
-    fun `check if error state was called`() = runBlockingTest {
+    fun `check if error state was called`() = runTest {
         // Given the use case returns an empty list with completed tasks by period
         loadCompletedTasksByPeriod.throwError = true
         val flow = viewModel.loadTracker()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ android_compile_sdk = "31"
 android_gradle_plugin = "7.3.0-beta03"
 android_min_sdk = "24"
 android_target_sdk = "31"
-kotlin = "1.5.30"
+kotlin = "1.6.10"
 
 # General dependencies
 logging = "2.1.23"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ datastore = "1.0.0"
 glance = "1.0.0-alpha03"
 
 # Compose
-compose = "1.0.3"
+compose = "1.1.1"
 compose_nav = "2.4.2"
 compose_viewmodel = "2.4.1"
 compose_activity = "1.4.0"
@@ -54,7 +54,6 @@ detekt = "1.20.0"
 # Project
 android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref = "android_gradle_plugin" }
 kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin_compiler_embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 
 # General dependencies
 logging = { module = "io.github.microutils:kotlin-logging", version.ref = "logging" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ compose_viewmodel = "2.4.1"
 compose_activity = "1.4.0"
 
 # Coroutines
-coroutines = "1.4.0"
+coroutines = "1.6.2"
 
 # Room
 room = "2.4.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ room = "2.4.2"
 koin = "3.2.0"
 
 # Accompanist
-accompanist = "0.20.2"
+accompanist = "0.23.1"
 
 # Test
 test_junit = "4.13.2"

--- a/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
+++ b/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
@@ -13,12 +13,12 @@ class CoroutineTestRule(
     val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
 ) : TestWatcher() {
 
-    override fun starting(description: Description?) {
+    override fun starting(description: Description) {
         super.starting(description)
         Dispatchers.setMain(testDispatcher)
     }
 
-    override fun finished(description: Description?) {
+    override fun finished(description: Description) {
         super.finished(description)
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()

--- a/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
+++ b/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
@@ -2,7 +2,8 @@ package com.escodro.test
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -10,7 +11,7 @@ import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutineTestRule(
-    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 ) : TestWatcher() {
 
     override fun starting(description: Description) {
@@ -21,6 +22,5 @@ class CoroutineTestRule(
     override fun finished(description: Description) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -11,6 +11,5 @@ repositories {
 dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.kotlin.compiler.embeddable)
     implementation(libs.detekt)
 }


### PR DESCRIPTION
Update Kotlin, Compose, Accompanist and Coroutines versions. Since these libraries depends on each others version, renovatebot will not be able to mix and match them.