### PR TITLE
✅ Remove unused Coroutines Test APIs

### DIFF
--- a/features/search/src/test/java/com/escodro/search/presentation/SearchViewModelTest.kt
+++ b/features/search/src/test/java/com/escodro/search/presentation/SearchViewModelTest.kt
@@ -5,7 +5,6 @@ import com.escodro.search.mapper.TaskSearchMapper
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
@@ -34,7 +33,6 @@ internal class SearchViewModelTest {
         val state = flow.first()
 
         // Then the state contain the queried task
-        advanceUntilIdle()
         require(state is SearchViewState.Loaded)
         Assert.assertEquals(numberOfValues, state.taskList.size)
     }

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
@@ -15,8 +15,6 @@ import com.escodro.task.presentation.fake.UpdateTaskTitleFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
@@ -85,7 +83,6 @@ internal class TaskDetailViewModelTest {
         // When the title is updated
         val newTitle = "title"
         viewModel.updateTitle(taskId = taskId, title = newTitle)
-        runCurrent() /* Advance typing debounce */
 
         // Then the task will be updated with given title
         Assert.assertTrue(updateTaskTitle.isTitleUpdated(FAKE_DOMAIN_TASK.id))
@@ -103,7 +100,6 @@ internal class TaskDetailViewModelTest {
         // When the description is updated
         val newDescription = "description"
         viewModel.updateDescription(taskId = taskId, description = newDescription)
-        advanceUntilIdle() /* Advance typing debounce */
 
         // Then the task will be updated with given description
         Assert.assertTrue(updateDescription.isDescriptionUpdated(FAKE_DOMAIN_TASK.id))


### PR DESCRIPTION
Removing the `advanceUntilIdle` and `runCurrent` from all tests since the new `runTest` API already automatically waits for all known coroutines. Info found the great article from @zsmb13, thanks!