### PR TITLE
✅ Allow some test class to be flaky

### DIFF
--- a/app/src/androidTest/java/com/escodro/alkaa/CategoryFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/CategoryFlowTest.kt
@@ -1,74 +1,47 @@
 package com.escodro.alkaa
 
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
-import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
-import com.adevinta.android.barista.rule.flaky.AllowFlaky
-import com.adevinta.android.barista.rule.flaky.FlakyTestRule
 import com.escodro.alkaa.navigation.NavGraph
 import com.escodro.category.presentation.semantics.ColorKey
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.provider.DaoProvider
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 import org.koin.test.inject
 import com.escodro.category.R as CategoryR
 
-internal class CategoryFlowTest : KoinTest {
+internal class CategoryFlowTest : FlakyTest(), KoinTest {
 
     private val daoProvider: DaoProvider by inject()
-
-    @get:Rule
-    val composeTestRule = createEmptyComposeRule()
-
-    @get:Rule
-    val flakyRule = FlakyTestRule()
-
-    private lateinit var scenario: ActivityScenario<ComponentActivity>
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Before
     fun setup() {
-        scenario = ActivityScenario.launch(ComponentActivity::class.java)
         runBlocking {
             // Clean all existing categories
             daoProvider.getCategoryDao().cleanTable()
         }
 
-        scenario.onActivity { activity ->
-            activity.setContent {
-                AlkaaTheme {
-                    NavGraph()
-                }
+        setContent {
+            AlkaaTheme {
+                NavGraph()
             }
         }
         navigateToCategory()
-    }
-
-    @After
-    fun tearDown() {
-        scenario.close()
     }
 
     @Test
@@ -113,10 +86,7 @@ internal class CategoryFlowTest : KoinTest {
         }
     }
 
-    // Flaky test only on the CI, works fine locally
-    // Please see https://issuetracker.google.com/issues/230857082
     @Test
-    @AllowFlaky(attempts = 5)
     fun test_updateCategoryColor() {
         val name = "Anime"
         val color = Color(0xFFFFCA28)

--- a/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
@@ -1,6 +1,5 @@
 package com.escodro.alkaa
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -8,24 +7,17 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.model.HomeSection
 import com.escodro.alkaa.navigation.NavGraph
 import com.escodro.designsystem.AlkaaTheme
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
-internal class HomeScreenTest {
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
+internal class HomeScreenTest : FlakyTest() {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             AlkaaTheme {
                 NavGraph()
             }

--- a/app/src/androidTest/java/com/escodro/alkaa/NotificationFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/NotificationFlowTest.kt
@@ -3,7 +3,6 @@ package com.escodro.alkaa
 import android.app.Notification
 import androidx.annotation.StringRes
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -15,12 +14,10 @@ import com.escodro.local.model.AlarmInterval
 import com.escodro.local.model.Task
 import com.escodro.local.provider.DaoProvider
 import com.escodro.task.R
-import com.escodro.test.DisableAnimationsRule
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.escodro.test.FlakyTest
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 import org.koin.test.inject
@@ -29,18 +26,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import com.escodro.alarm.R as AlarmR
 
-@OptIn(ExperimentalCoroutinesApi::class)
-internal class NotificationFlowTest : KoinTest {
+internal class NotificationFlowTest : FlakyTest(), KoinTest {
 
     private val daoProvider: DaoProvider by inject()
 
     private val scheduleAlarm: ScheduleAlarm by inject()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -50,7 +40,7 @@ internal class NotificationFlowTest : KoinTest {
         runBlocking {
             daoProvider.getTaskDao().cleanTable()
         }
-        composeTestRule.setContent {
+        setContent {
             AlkaaTheme {
                 NavGraph()
             }

--- a/app/src/androidTest/java/com/escodro/alkaa/PreferenceFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/PreferenceFlowTest.kt
@@ -1,33 +1,25 @@
 package com.escodro.alkaa
 
 import androidx.annotation.StringRes
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.navigation.NavGraph
 import com.escodro.core.extension.getVersionName
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import com.escodro.core.R as CoreR
 import com.escodro.preference.R as PrefR
 
-internal class PreferenceFlowTest {
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
+internal class PreferenceFlowTest : FlakyTest() {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             NavGraph()
         }
         navigateToPreferences()

--- a/app/src/androidTest/java/com/escodro/alkaa/SearchFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/SearchFlowTest.kt
@@ -2,7 +2,6 @@ package com.escodro.alkaa
 
 import androidx.annotation.StringRes
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -13,24 +12,17 @@ import com.escodro.alkaa.fake.FAKE_TASKS
 import com.escodro.alkaa.navigation.NavGraph
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.provider.DaoProvider
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 import org.koin.test.inject
 import com.escodro.search.R as SearchR
 
-internal class SearchFlowTest : KoinTest {
+internal class SearchFlowTest : FlakyTest(), KoinTest {
 
     private val daoProvider: DaoProvider by inject()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -44,7 +36,7 @@ internal class SearchFlowTest : KoinTest {
             FAKE_TASKS.forEach { task -> daoProvider.getTaskDao().insertTask(task) }
         }
 
-        composeTestRule.setContent {
+        setContent {
             AlkaaTheme {
                 NavGraph()
             }

--- a/app/src/androidTest/java/com/escodro/alkaa/TaskFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/TaskFlowTest.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -18,12 +17,11 @@ import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.model.Category
 import com.escodro.local.provider.DaoProvider
 import com.escodro.task.presentation.category.ChipNameKey
-import com.escodro.test.DisableAnimationsRule
 import com.escodro.test.Events
+import com.escodro.test.FlakyTest
 import com.escodro.test.assertIsChecked
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 import org.koin.test.inject
@@ -31,15 +29,9 @@ import org.koin.test.mock.declare
 import java.util.Calendar
 import com.escodro.task.R as TaskR
 
-internal class TaskFlowTest : KoinTest {
+internal class TaskFlowTest : FlakyTest(), KoinTest {
 
     private val daoProvider: DaoProvider by inject()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -60,7 +52,7 @@ internal class TaskFlowTest : KoinTest {
         // Replace Debouncer with a Immediate Executor
         declare<CoroutineDebouncer> { CoroutinesDebouncerFake() }
 
-        composeTestRule.setContent {
+        setContent {
             AlkaaTheme {
                 NavGraph()
             }

--- a/app/src/androidTest/java/com/escodro/alkaa/TaskListFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/TaskListFlowTest.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -16,24 +15,17 @@ import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.model.Category
 import com.escodro.local.provider.DaoProvider
 import com.escodro.task.presentation.list.CheckboxNameKey
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 import org.koin.test.inject
 import com.escodro.task.R as TaskR
 
-internal class TaskListFlowTest : KoinTest {
+internal class TaskListFlowTest : FlakyTest(), KoinTest {
 
     private val daoProvider: DaoProvider by inject()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -50,7 +42,7 @@ internal class TaskListFlowTest : KoinTest {
                 getCategoryDao().insertCategory(Category(name = "Work", color = "#519872"))
             }
         }
-        composeTestRule.setContent {
+        setContent {
             AlkaaTheme {
                 NavGraph()
             }

--- a/features/task/src/androidTest/java/com/escodro/task/AlarmPermissionFlowTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/AlarmPermissionFlowTest.kt
@@ -1,49 +1,24 @@
 package com.escodro.task
 
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.task.fake.PermissionStateFake
 import com.escodro.task.presentation.detail.alarm.AlarmSelectionContent
 import com.escodro.task.presentation.detail.alarm.AlarmSelectionState
-import com.escodro.test.DisableAnimationsRule
+import com.escodro.test.FlakyTest
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.PermissionStatus
-import org.junit.After
 import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalPermissionsApi::class)
-internal class AlarmPermissionFlowTest {
-
-    @get:Rule
-    val composeTestRule = createEmptyComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
+internal class AlarmPermissionFlowTest : FlakyTest() {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    private lateinit var scenario: ActivityScenario<ComponentActivity>
-
-    @Before
-    fun setup() {
-        scenario = ActivityScenario.launch(ComponentActivity::class.java)
-    }
-
-    @After
-    fun tearDown() {
-        scenario.close()
-    }
 
     @Test
     fun test_notificationPermissionGrantedDoesNotShowDialog() {
@@ -148,18 +123,16 @@ internal class AlarmPermissionFlowTest {
         permissionState: PermissionState,
         hasAlarmPermission: Boolean
     ) {
-        scenario.onActivity { activity ->
-            activity.setContent {
-                AlkaaTheme {
-                    AlarmSelectionContent(
-                        context = LocalContext.current,
-                        state = state,
-                        permissionState = permissionState,
-                        hasAlarmPermission = { hasAlarmPermission },
-                        onAlarmUpdate = {},
-                        onIntervalSelect = {}
-                    )
-                }
+        setContent {
+            AlkaaTheme {
+                AlarmSelectionContent(
+                    context = LocalContext.current,
+                    state = state,
+                    permissionState = permissionState,
+                    hasAlarmPermission = { hasAlarmPermission },
+                    onAlarmUpdate = {},
+                    onIntervalSelect = {}
+                )
             }
         }
     }

--- a/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
+++ b/features/task/src/androidTest/java/com/escodro/task/AlarmSelectionTest.kt
@@ -1,47 +1,22 @@
 package com.escodro.task
 
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.alarm.AlarmSelection
-import com.escodro.test.DisableAnimationsRule
 import com.escodro.test.Events
-import org.junit.After
-import org.junit.Before
-import org.junit.Rule
+import com.escodro.test.FlakyTest
 import org.junit.Test
 import java.util.Calendar
 
-internal class AlarmSelectionTest {
-
-    @get:Rule
-    val composeTestRule = createEmptyComposeRule()
-
-    @get:Rule
-    val disableAnimationsRule = DisableAnimationsRule()
+internal class AlarmSelectionTest : FlakyTest() {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    private lateinit var scenario: ActivityScenario<ComponentActivity>
-
-    @Before
-    fun setup() {
-        scenario = ActivityScenario.launch(ComponentActivity::class.java)
-    }
-
-    @After
-    fun tearDown() {
-        scenario.close()
-    }
 
     @Test
     fun test_addAlarm() {
@@ -169,18 +144,16 @@ internal class AlarmSelectionTest {
         hasExactAlarmPermission: Boolean = true,
         shouldAskForNotificationPermission: Boolean = false
     ) {
-        scenario.onActivity { activity ->
-            activity.setContent {
-                AlkaaTheme {
-                    AlarmSelection(
-                        calendar = null,
-                        interval = AlarmInterval.NEVER,
-                        onAlarmUpdate = {},
-                        onIntervalSelect = {},
-                        hasAlarmPermission = { hasExactAlarmPermission },
-                        shouldCheckNotificationPermission = shouldAskForNotificationPermission
-                    )
-                }
+        setContent {
+            AlkaaTheme {
+                AlarmSelection(
+                    calendar = null,
+                    interval = AlarmInterval.NEVER,
+                    onAlarmUpdate = {},
+                    onIntervalSelect = {},
+                    hasAlarmPermission = { hasExactAlarmPermission },
+                    shouldCheckNotificationPermission = shouldAskForNotificationPermission
+                )
             }
         }
     }
@@ -189,18 +162,16 @@ internal class AlarmSelectionTest {
         calendar: Calendar,
         alarmInterval: AlarmInterval
     ) {
-        scenario.onActivity { activity ->
-            activity.setContent {
-                AlkaaTheme {
-                    AlarmSelection(
-                        calendar = calendar,
-                        interval = alarmInterval,
-                        onAlarmUpdate = {},
-                        onIntervalSelect = {},
-                        hasAlarmPermission = { true },
-                        shouldCheckNotificationPermission = false
-                    )
-                }
+        setContent {
+            AlkaaTheme {
+                AlarmSelection(
+                    calendar = calendar,
+                    interval = alarmInterval,
+                    onAlarmUpdate = {},
+                    onIntervalSelect = {},
+                    hasAlarmPermission = { true },
+                    shouldCheckNotificationPermission = false
+                )
             }
         }
     }

--- a/libraries/test/build.gradle.kts
+++ b/libraries/test/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.escodro.android-library")
+    id("com.escodro.android-compose")
 }
 
 android {
@@ -22,7 +23,8 @@ dependencies {
 
     api(libs.coroutines.test)
 
-    implementation(libs.compose.uitest) {
+    api(libs.compose.activity)
+    implementation(libs.bundles.composetest) {
         exclude(group = "androidx.core", module = "core-ktx")
         exclude(group = "androidx.fragment", module = "fragment")
         exclude(group = "androidx.customview", module = "customview")

--- a/libraries/test/src/main/java/com/escodro/test/FlakyTest.kt
+++ b/libraries/test/src/main/java/com/escodro/test/FlakyTest.kt
@@ -1,0 +1,55 @@
+package com.escodro.test
+
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import com.adevinta.android.barista.rule.flaky.FlakyTestRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+
+/**
+ * Allows flaky tests to re-execute if not passing.
+ *
+ * Unfortunately this is only happening in the CI, while using Gradle Managed Devices and I'm not
+ * able to reproduce it locally. So, the silver tape solution here is basically try to execute it
+ * again and hope that the Activity is on the right state.
+ */
+open class FlakyTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @get:Rule
+    val flakyRule = FlakyTestRule().apply { allowFlakyAttemptsByDefault(defaultAttempts = 10) }
+
+    @get:Rule
+    val disableAnimationsRule = DisableAnimationsRule()
+
+    private lateinit var scenario: ActivityScenario<ComponentActivity>
+
+    @Before
+    fun createScenario() {
+        scenario = ActivityScenario.launch(ComponentActivity::class.java)
+    }
+
+    @After
+    fun closeScenario() {
+        scenario.close()
+    }
+
+    /**
+     * Loads the Compose content in the UI for testing.
+     *
+     * @param content the content to be loaded
+     */
+    fun setContent(content: @Composable () -> Unit) {
+        scenario.onActivity { activity ->
+            activity.setContent {
+                content()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately, the Instrumented Tests are failing a lot in the CI due to the Compose + Gradle Managed Devices usage. Since I'm not able to reproduce any of those failures locally, the silver tape solution now is basically creating a rule to allow them to run again. The extra setup is required due to how Compose default rules create the Activities.

By having a single rule and just applying it to the Tests, it's possible to have a single source of truth. Then we can just remove it in the future when Managed Devices are more stable.

For more info, please take a look:
https://proandroiddev.com/managing-flaky-tests-in-jetpack-compose-89c598590068