### PR TITLE
👷 Replace Gradle Managed Devices for ReactiveCircus Plugin

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  androidTest:
     runs-on: macos-latest
 
     steps:
@@ -24,7 +24,12 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Run instrumented tests
-        run: ./gradlew alkaaDevicesGroupDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+        #run: ./gradlew alkaaDevicesGroupDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_atd
+          script: ./gradlew app:connectedAndroidTest
 
       - name: Save Test Results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Android Gradle Managed Devices are very unstable recently, basically failing every single job due to some unknown system crash. I believe that this started to happen after the API 33 upgrade, but we need to wait and see.

The solution, for now, is trying to revert to ReactiveCircus/android-emulator-runner.