### PR TITLE
Invoke app specific "Alarms & reminders" settings

### DIFF
--- a/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/PermissionDialogs.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/PermissionDialogs.kt
@@ -29,6 +29,7 @@ internal fun AlarmPermissionDialog(
                 val intent = Intent().apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     action = Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
+                    data = Uri.fromParts("package", context.packageName, null)
                 }
                 context.startActivity(intent)
                 onCloseDialog()


### PR DESCRIPTION
Specify the application package name to directly Invoke "Alarms & reminders" management specific to the app.
Described on the [ACTION_REQUEST_SCHEDULE_EXACT_ALARM](https://developer.android.com/reference/android/provider/Settings#ACTION_REQUEST_SCHEDULE_EXACT_ALARM) permission page.