### PR TITLE
👷‍ Executes CI on Pull Request

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -1,6 +1,12 @@
 name: instrumented tests
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: build
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Today the trigger is only "on push", which is not good when external contributors try to submit PRs. Updating to also trigger "on pull request" and only when pushing to main. This configuration is based on the Accompanist one.