### PR TITLE
Update Glance to latest alpha version

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
+++ b/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
@@ -2,7 +2,9 @@ package com.escodro.alkaa.di
 
 import com.escodro.alkaa.presentation.MainViewModel
 import com.escodro.alkaa.presentation.mapper.AppThemeOptionsMapper
+import com.escodro.core.coroutines.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.SupervisorJob
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.factoryOf
@@ -17,4 +19,6 @@ val appModule = module {
     viewModelOf(::MainViewModel)
 
     factoryOf(::AppThemeOptionsMapper)
+
+    single(ApplicationScope) { MainScope() }
 }

--- a/features/category/src/main/java/com/escodro/category/di/CategoryModule.kt
+++ b/features/category/src/main/java/com/escodro/category/di/CategoryModule.kt
@@ -5,6 +5,8 @@ import com.escodro.category.presentation.bottomsheet.CategoryAddViewModel
 import com.escodro.category.presentation.bottomsheet.CategoryEditViewModel
 import com.escodro.category.presentation.list.CategoryListViewModelImpl
 import com.escodro.categoryapi.presentation.CategoryListViewModel
+import com.escodro.core.coroutines.ApplicationScope
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.bind
@@ -16,7 +18,15 @@ import org.koin.dsl.module
 val categoryModule = module {
     viewModelOf(::CategoryListViewModelImpl) bind CategoryListViewModel::class
     viewModelOf(::CategoryAddViewModel)
-    viewModelOf(::CategoryEditViewModel)
+    viewModel {
+        CategoryEditViewModel(
+            loadCategoryUseCase = get(),
+            updateCategoryUseCase = get(),
+            deleteCategoryUseCase = get(),
+            applicationScope = get(ApplicationScope),
+            mapper = get()
+        )
+    }
 
     // Mapper
     factoryOf(::CategoryMapper)

--- a/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModel.kt
+++ b/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModel.kt
@@ -1,21 +1,22 @@
 package com.escodro.category.presentation.bottomsheet
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.category.mapper.CategoryMapper
 import com.escodro.categoryapi.model.Category
 import com.escodro.domain.usecase.category.AddCategory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 internal class CategoryAddViewModel(
     private val addCategoryUseCase: AddCategory,
+    private val applicationScope: CoroutineScope,
     private val categoryMapper: CategoryMapper
 ) : ViewModel() {
 
     fun addCategory(category: Category) {
         if (category.name.isEmpty()) return
 
-        viewModelScope.launch {
+        applicationScope.launch {
             val domainCategory = categoryMapper.toDomain(category)
             addCategoryUseCase.invoke(domainCategory)
         }

--- a/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModel.kt
+++ b/features/category/src/main/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModel.kt
@@ -1,12 +1,12 @@
 package com.escodro.category.presentation.bottomsheet
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.category.mapper.CategoryMapper
 import com.escodro.categoryapi.model.Category
 import com.escodro.domain.usecase.category.DeleteCategory
 import com.escodro.domain.usecase.category.LoadCategory
 import com.escodro.domain.usecase.category.UpdateCategory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
@@ -14,6 +14,7 @@ internal class CategoryEditViewModel(
     private val loadCategoryUseCase: LoadCategory,
     private val updateCategoryUseCase: UpdateCategory,
     private val deleteCategoryUseCase: DeleteCategory,
+    private val applicationScope: CoroutineScope,
     private val mapper: CategoryMapper
 ) : ViewModel() {
 
@@ -30,13 +31,13 @@ internal class CategoryEditViewModel(
     fun updateCategory(category: Category) {
         if (category.name.isEmpty()) return
 
-        viewModelScope.launch {
+        applicationScope.launch {
             val domainCategory = mapper.toDomain(category)
             updateCategoryUseCase(domainCategory)
         }
     }
 
-    fun deleteCategory(category: Category) = viewModelScope.launch {
+    fun deleteCategory(category: Category) = applicationScope.launch {
         val domainCategory = mapper.toDomain(category)
         deleteCategoryUseCase(domainCategory)
     }

--- a/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModelTest.kt
+++ b/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryAddViewModelTest.kt
@@ -7,6 +7,7 @@ import com.escodro.categoryapi.model.Category
 import com.escodro.core.extension.toStringColor
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -15,14 +16,18 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CategoryAddViewModelTest {
 
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
+
     private val addCategory = AddCategoryFake()
 
     private val categoryMapper = CategoryMapper()
 
-    private val viewModel = CategoryAddViewModel(addCategory, categoryMapper)
-
-    @get:Rule
-    val coroutinesRule = CoroutineTestRule()
+    private val viewModel = CategoryAddViewModel(
+        addCategoryUseCase = addCategory,
+        applicationScope = TestScope(coroutinesRule.testDispatcher),
+        categoryMapper
+    )
 
     @Before
     fun setup() {

--- a/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModelTest.kt
+++ b/features/category/src/test/java/com/escodro/category/presentation/bottomsheet/CategoryEditViewModelTest.kt
@@ -10,6 +10,7 @@ import com.escodro.categoryapi.model.Category
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -19,6 +20,9 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CategoryEditViewModelTest {
 
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
+
     private val loadCategoryFake = LoadCategoryFake()
 
     private val updateCategory = UpdateCategoryFake()
@@ -27,11 +31,13 @@ internal class CategoryEditViewModelTest {
 
     private val mapper = CategoryMapper()
 
-    private val viewModel =
-        CategoryEditViewModel(loadCategoryFake, updateCategory, deleteCategory, mapper)
-
-    @get:Rule
-    val coroutinesRule = CoroutineTestRule()
+    private val viewModel = CategoryEditViewModel(
+        loadCategoryUseCase = loadCategoryFake,
+        updateCategoryUseCase = updateCategory,
+        deleteCategoryUseCase = deleteCategory,
+        applicationScope = TestScope(coroutinesRule.testDispatcher),
+        mapper = mapper
+    )
 
     @Before
     fun setup() {

--- a/features/glance/build.gradle.kts
+++ b/features/glance/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.escodro.android-compose")
+    kotlin("plugin.serialization").version(libs.versions.kotlin)
 }
 
 dependencies {
@@ -9,4 +10,9 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.compose)
     implementation(libs.androidx.glance)
+
+    // Unwanted dependencies to keep all the Glance-related logic on this module
+    implementation(libs.androidx.workmanager)
+    implementation(libs.serialization)
+    implementation(libs.androidx.datastore)
 }

--- a/features/glance/src/main/AndroidManifest.xml
+++ b/features/glance/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application>
         <receiver
-            android:name=".presentation.TaskListGlanceReceiver"
+            android:name=".data.TaskListGlanceReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/features/glance/src/main/java/com/escodro/glance/data/TaskListGlanceReceiver.kt
+++ b/features/glance/src/main/java/com/escodro/glance/data/TaskListGlanceReceiver.kt
@@ -1,0 +1,21 @@
+package com.escodro.glance.data
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import com.escodro.glance.presentation.TaskListGlanceWidget
+
+internal class TaskListGlanceReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget: GlanceAppWidget = TaskListGlanceWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        TaskListUpdaterWorker.enqueue(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        TaskListUpdaterWorker.cancel(context)
+    }
+}

--- a/features/glance/src/main/java/com/escodro/glance/data/TaskListGlanceUpdater.kt
+++ b/features/glance/src/main/java/com/escodro/glance/data/TaskListGlanceUpdater.kt
@@ -1,4 +1,4 @@
-package com.escodro.glance.presentation
+package com.escodro.glance.data
 
 import com.escodro.domain.usecase.task.UpdateTaskStatus
 import com.escodro.domain.usecase.taskwithcategory.LoadUncompletedTasks
@@ -7,7 +7,10 @@ import com.escodro.glance.model.Task
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-internal class TaskListGlanceViewModel(
+/**
+ * Class responsible to provide data and update the Task List in the Glance Widget.
+ */
+internal class TaskListGlanceUpdater(
     private val loadAllTasksUseCase: LoadUncompletedTasks,
     private val updateTaskStatus: UpdateTaskStatus,
     private val taskMapper: TaskMapper

--- a/features/glance/src/main/java/com/escodro/glance/data/TaskListStateDefinition.kt
+++ b/features/glance/src/main/java/com/escodro/glance/data/TaskListStateDefinition.kt
@@ -1,0 +1,53 @@
+package com.escodro.glance.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import androidx.datastore.dataStoreFile
+import androidx.glance.state.GlanceStateDefinition
+import com.escodro.glance.model.Task
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Custom [GlanceStateDefinition] to store the widget-related data in a [DataStore].
+ *
+ * Ideally, all this data logic would stay in the `:data` layer, however once the processing here is
+ * too specific for the Glance logic, I decided to keep it here. Moving some logic across other
+ * layers would make it confusing and the use cases would need to know from which datasource the
+ * data is available. There is no pretty solution for now.
+ */
+internal object TaskListStateDefinition : GlanceStateDefinition<List<Task>> {
+
+    private const val DATA_STORE_FILENAME = "taskList"
+
+    private val Context.datastore by dataStore(DATA_STORE_FILENAME, TaskListSerializer)
+
+    override suspend fun getDataStore(context: Context, fileKey: String): DataStore<List<Task>> =
+        context.datastore
+
+    override fun getLocation(context: Context, fileKey: String): File =
+        context.dataStoreFile(DATA_STORE_FILENAME)
+
+    /**
+     * Custom serializer to write and read data from [DataStore].
+     */
+    @OptIn(ExperimentalSerializationApi::class)
+    object TaskListSerializer : Serializer<List<Task>> {
+
+        override val defaultValue: List<Task>
+            get() = emptyList()
+
+        override suspend fun readFrom(input: InputStream): List<Task> =
+            Json.decodeFromStream(input)
+
+        override suspend fun writeTo(t: List<Task>, output: OutputStream) =
+            Json.encodeToStream(t, output)
+    }
+}

--- a/features/glance/src/main/java/com/escodro/glance/data/TaskListUpdaterWorker.kt
+++ b/features/glance/src/main/java/com/escodro/glance/data/TaskListUpdaterWorker.kt
@@ -1,0 +1,68 @@
+package com.escodro.glance.data
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.appwidget.updateAll
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.escodro.glance.model.Task
+import com.escodro.glance.presentation.TaskListGlanceWidget
+import kotlinx.coroutines.flow.first
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Worker to update the Task List in the widget. A worker is needed here because the process might
+ * be dead during between the writing, reading and displaying of the information.
+ */
+internal class TaskListUpdaterWorker(
+    private val context: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(context, workerParameters), KoinComponent {
+
+    private val viewModel: TaskListGlanceUpdater by inject()
+
+    override suspend fun doWork(): Result {
+        val manager = GlanceAppWidgetManager(context)
+        val glanceIds = manager.getGlanceIds(TaskListGlanceWidget::class.java)
+        val list = viewModel.loadTaskList().first()
+        updateWidgets(glanceIds, list)
+        return Result.success()
+    }
+
+    private suspend fun updateWidgets(glanceIds: List<GlanceId>, list: List<Task>) {
+        glanceIds.forEach {
+            updateAppWidgetState(
+                context = context,
+                definition = TaskListStateDefinition,
+                glanceId = it,
+                updateState = { list }
+            )
+            TaskListGlanceWidget().updateAll(context)
+        }
+    }
+
+    companion object {
+        private val uniqueWorkName = TaskListUpdaterWorker::class.java.simpleName
+
+        fun enqueue(context: Context) {
+            val manager = WorkManager.getInstance(context)
+            val requestBuilder = OneTimeWorkRequestBuilder<TaskListUpdaterWorker>()
+
+            manager.enqueueUniqueWork(
+                uniqueWorkName,
+                ExistingWorkPolicy.KEEP,
+                requestBuilder.build()
+            )
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(uniqueWorkName)
+        }
+    }
+}

--- a/features/glance/src/main/java/com/escodro/glance/di/GlanceModule.kt
+++ b/features/glance/src/main/java/com/escodro/glance/di/GlanceModule.kt
@@ -1,10 +1,11 @@
 package com.escodro.glance.di
 
 import com.escodro.domain.interactor.GlanceInteractor
+import com.escodro.glance.data.TaskListGlanceUpdater
 import com.escodro.glance.interactor.GlanceInteractorImpl
 import com.escodro.glance.mapper.TaskMapper
-import com.escodro.glance.presentation.TaskListGlanceViewModel
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -14,7 +15,7 @@ import org.koin.dsl.module
 val glanceModule = module {
 
     // Presentation
-    factoryOf(::TaskListGlanceViewModel)
+    singleOf(::TaskListGlanceUpdater)
 
     // Interactor
     factoryOf(::GlanceInteractorImpl) bind GlanceInteractor::class

--- a/features/glance/src/main/java/com/escodro/glance/interactor/GlanceInteractorImpl.kt
+++ b/features/glance/src/main/java/com/escodro/glance/interactor/GlanceInteractorImpl.kt
@@ -1,14 +1,16 @@
 package com.escodro.glance.interactor
 
+import android.content.Context
 import com.escodro.domain.interactor.GlanceInteractor
+import com.escodro.glance.data.TaskListUpdaterWorker
 import com.escodro.glance.presentation.TaskListGlanceWidget
 
-internal class GlanceInteractorImpl : GlanceInteractor {
+internal class GlanceInteractorImpl(private val context: Context) : GlanceInteractor {
 
     /**
      * Updates all the [TaskListGlanceWidget] to load the latest data.
      */
     override suspend fun onTaskListUpdated() {
-        TaskListGlanceWidget().loadData()
+        TaskListUpdaterWorker.enqueue(context)
     }
 }

--- a/features/glance/src/main/java/com/escodro/glance/model/Task.kt
+++ b/features/glance/src/main/java/com/escodro/glance/model/Task.kt
@@ -1,3 +1,6 @@
 package com.escodro.glance.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 internal data class Task(val id: Long, val title: String)

--- a/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceReceiver.kt
+++ b/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceReceiver.kt
@@ -1,9 +1,0 @@
-package com.escodro.glance.presentation
-
-import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-
-internal class TaskListGlanceReceiver : GlanceAppWidgetReceiver() {
-
-    override val glanceAppWidget: GlanceAppWidget = TaskListGlanceWidget().apply { loadData() }
-}

--- a/features/glance/src/main/java/com/escodro/glance/presentation/UpdateTaskStatusAction.kt
+++ b/features/glance/src/main/java/com/escodro/glance/presentation/UpdateTaskStatusAction.kt
@@ -5,16 +5,21 @@ import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
 import com.escodro.domain.interactor.GlanceInteractor
+import com.escodro.glance.data.TaskListGlanceUpdater
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 internal class UpdateTaskStatusAction : ActionCallback, KoinComponent {
 
-    private val viewModel: TaskListGlanceViewModel by inject()
+    private val viewModel: TaskListGlanceUpdater by inject()
 
     private val glanceInteractor: GlanceInteractor by inject()
 
-    override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters
+    ) {
         val taskId = parameters[TaskIdKey]?.toLong() ?: return
         viewModel.updateTaskAsCompleted(taskId)
         glanceInteractor.onTaskListUpdated()

--- a/features/glance/src/main/res/layout/widget_task_list_preview.xml
+++ b/features/glance/src/main/res/layout/widget_task_list_preview.xml
@@ -1,6 +1,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="200dp"
-    android:layout_height="200dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@android:color/background_light"
     android:orientation="vertical"
     android:padding="8dp">

--- a/features/preference/src/main/java/com/escodro/preference/di/PreferenceModule.kt
+++ b/features/preference/src/main/java/com/escodro/preference/di/PreferenceModule.kt
@@ -1,8 +1,9 @@
 package com.escodro.preference.di
 
+import com.escodro.core.coroutines.ApplicationScope
 import com.escodro.preference.AppThemeOptionsMapper
 import com.escodro.preference.presentation.PreferenceViewModel
-import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -11,7 +12,14 @@ import org.koin.dsl.module
  */
 val preferenceModule = module {
 
-    viewModelOf(::PreferenceViewModel)
+    viewModel {
+        PreferenceViewModel(
+            updateThemeUseCase = get(),
+            loadAppTheme = get(),
+            applicationScope = get(ApplicationScope),
+            mapper = get()
+        )
+    }
 
     factoryOf(::AppThemeOptionsMapper)
 }

--- a/features/preference/src/main/java/com/escodro/preference/presentation/PreferenceViewModel.kt
+++ b/features/preference/src/main/java/com/escodro/preference/presentation/PreferenceViewModel.kt
@@ -1,11 +1,11 @@
 package com.escodro.preference.presentation
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.domain.usecase.preferences.LoadAppTheme
 import com.escodro.domain.usecase.preferences.UpdateAppTheme
 import com.escodro.preference.AppThemeOptionsMapper
 import com.escodro.preference.model.AppThemeOptions
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -13,12 +13,13 @@ import kotlinx.coroutines.launch
 internal class PreferenceViewModel(
     private val updateThemeUseCase: UpdateAppTheme,
     private val loadAppTheme: LoadAppTheme,
+    private val applicationScope: CoroutineScope,
     private val mapper: AppThemeOptionsMapper
 ) : ViewModel() {
 
     fun loadCurrentTheme(): Flow<AppThemeOptions> = loadAppTheme().map { mapper.toViewData(it) }
 
-    fun updateTheme(theme: AppThemeOptions) = viewModelScope.launch {
+    fun updateTheme(theme: AppThemeOptions) = applicationScope.launch {
         val updatedTheme = mapper.toDomain(theme)
         updateThemeUseCase(updatedTheme)
     }

--- a/features/task/src/main/java/com/escodro/task/di/TaskModule.kt
+++ b/features/task/src/main/java/com/escodro/task/di/TaskModule.kt
@@ -1,5 +1,6 @@
 package com.escodro.task.di
 
+import com.escodro.core.coroutines.ApplicationScope
 import com.escodro.task.mapper.AlarmIntervalMapper
 import com.escodro.task.mapper.CategoryMapper
 import com.escodro.task.mapper.TaskMapper
@@ -8,7 +9,7 @@ import com.escodro.task.presentation.add.AddTaskViewModel
 import com.escodro.task.presentation.detail.alarm.TaskAlarmViewModel
 import com.escodro.task.presentation.detail.main.TaskDetailViewModel
 import com.escodro.task.presentation.list.TaskListViewModel
-import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -18,10 +19,35 @@ import org.koin.dsl.module
 val taskModule = module {
 
     // Presentation
-    viewModelOf(::TaskListViewModel)
-    viewModelOf(::TaskDetailViewModel)
-    viewModelOf(::TaskAlarmViewModel)
-    viewModelOf(::AddTaskViewModel)
+    viewModel {
+        TaskListViewModel(
+            loadAllTasksUseCase = get(),
+            updateTaskStatusUseCase = get(),
+            applicationScope = get(ApplicationScope),
+            taskWithCategoryMapper = get()
+        )
+    }
+    viewModel {
+        TaskDetailViewModel(
+            loadTaskUseCase = get(),
+            updateTaskTitle = get(),
+            updateTaskDescription = get(),
+            updateTaskCategory = get(),
+            coroutineDebouncer = get(),
+            applicationScope = get(ApplicationScope),
+            taskMapper = get()
+        )
+    }
+    viewModel {
+        TaskAlarmViewModel(
+            scheduleAlarmUseCase = get(),
+            updateTaskAsRepeatingUseCase = get(),
+            cancelAlarmUseCase = get(),
+            applicationScope = get(ApplicationScope),
+            alarmIntervalMapper = get()
+        )
+    }
+    viewModel { AddTaskViewModel(addTaskUseCase = get(), applicationScope = get(ApplicationScope)) }
 
     // Mappers
     factoryOf(::AlarmIntervalMapper)

--- a/features/task/src/main/java/com/escodro/task/presentation/add/AddTaskViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/add/AddTaskViewModel.kt
@@ -1,20 +1,21 @@
 package com.escodro.task.presentation.add
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.domain.model.Task
 import com.escodro.domain.usecase.task.AddTask
 import com.escodro.task.presentation.detail.main.CategoryId
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 internal class AddTaskViewModel(
-    private val addTaskUseCase: AddTask
+    private val addTaskUseCase: AddTask,
+    private val applicationScope: CoroutineScope
 ) : ViewModel() {
 
     fun addTask(title: String, categoryId: CategoryId?) {
         if (title.isBlank()) return
 
-        viewModelScope.launch {
+        applicationScope.launch {
             val task = Task(title = title, categoryId = categoryId?.value)
             addTaskUseCase.invoke(task)
         }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/alarm/TaskAlarmViewModel.kt
@@ -1,13 +1,13 @@
 package com.escodro.task.presentation.detail.alarm
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.domain.usecase.alarm.CancelAlarm
 import com.escodro.domain.usecase.alarm.ScheduleAlarm
 import com.escodro.domain.usecase.alarm.UpdateTaskAsRepeating
 import com.escodro.task.mapper.AlarmIntervalMapper
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.main.TaskId
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Calendar
 
@@ -15,10 +15,11 @@ internal class TaskAlarmViewModel(
     private val scheduleAlarmUseCase: ScheduleAlarm,
     private val updateTaskAsRepeatingUseCase: UpdateTaskAsRepeating,
     private val cancelAlarmUseCase: CancelAlarm,
+    private val applicationScope: CoroutineScope,
     private val alarmIntervalMapper: AlarmIntervalMapper
 ) : ViewModel() {
 
-    fun updateAlarm(taskId: TaskId, alarm: Calendar?) = viewModelScope.launch {
+    fun updateAlarm(taskId: TaskId, alarm: Calendar?) = applicationScope.launch {
         if (alarm != null) {
             scheduleAlarmUseCase(taskId.value, alarm)
         } else {
@@ -26,7 +27,7 @@ internal class TaskAlarmViewModel(
         }
     }
 
-    fun setRepeating(taskId: TaskId, alarmInterval: AlarmInterval) = viewModelScope.launch {
+    fun setRepeating(taskId: TaskId, alarmInterval: AlarmInterval) = applicationScope.launch {
         val interval = alarmIntervalMapper.toDomain(alarmInterval)
         updateTaskAsRepeatingUseCase(taskId.value, interval)
     }

--- a/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetailViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/detail/main/TaskDetailViewModel.kt
@@ -8,16 +8,19 @@ import com.escodro.domain.usecase.task.UpdateTaskCategory
 import com.escodro.domain.usecase.task.UpdateTaskDescription
 import com.escodro.domain.usecase.task.UpdateTaskTitle
 import com.escodro.task.mapper.TaskMapper
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
+@Suppress("LongParameterList")
 internal class TaskDetailViewModel(
     private val loadTaskUseCase: LoadTask,
     private val updateTaskTitle: UpdateTaskTitle,
     private val updateTaskDescription: UpdateTaskDescription,
     private val updateTaskCategory: UpdateTaskCategory,
     private val coroutineDebouncer: CoroutineDebouncer,
+    private val applicationScope: CoroutineScope,
     private val taskMapper: TaskMapper
 ) : ViewModel() {
 
@@ -43,7 +46,7 @@ internal class TaskDetailViewModel(
         }
 
     fun updateCategory(taskId: TaskId, categoryId: CategoryId) =
-        viewModelScope.launch {
+        applicationScope.launch {
             updateTaskCategory(taskId = taskId.value, categoryId = categoryId.value)
         }
 }

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskListViewModel.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskListViewModel.kt
@@ -1,14 +1,13 @@
 package com.escodro.task.presentation.list
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.escodro.domain.usecase.task.UpdateTaskStatus
 import com.escodro.domain.usecase.taskwithcategory.LoadUncompletedTasks
 import com.escodro.task.mapper.TaskWithCategoryMapper
 import com.escodro.task.model.TaskWithCategory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -20,6 +19,7 @@ import kotlinx.coroutines.launch
 internal class TaskListViewModel(
     private val loadAllTasksUseCase: LoadUncompletedTasks,
     private val updateTaskStatusUseCase: UpdateTaskStatus,
+    private val applicationScope: CoroutineScope,
     private val taskWithCategoryMapper: TaskWithCategoryMapper
 ) : ViewModel() {
 
@@ -37,7 +37,7 @@ internal class TaskListViewModel(
             }
     }
 
-    fun updateTaskStatus(item: TaskWithCategory) = viewModelScope.launch {
+    fun updateTaskStatus(item: TaskWithCategory) = applicationScope.launch {
         updateTaskStatusUseCase(item.task.id)
     }
 }

--- a/features/task/src/test/java/com/escodro/task/presentation/add/AddTaskViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/add/AddTaskViewModelTest.kt
@@ -4,6 +4,7 @@ import com.escodro.task.presentation.detail.main.CategoryId
 import com.escodro.task.presentation.fake.AddTaskFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -12,12 +13,15 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class AddTaskViewModelTest {
 
-    private val addTask = AddTaskFake()
-
-    private val viewModel = AddTaskViewModel(addTask)
-
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    private val addTask = AddTaskFake()
+
+    private val viewModel = AddTaskViewModel(
+        addTaskUseCase = addTask,
+        applicationScope = TestScope(coroutineTestRule.testDispatcher)
+    )
 
     @Before
     fun setup() {

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskAlarmViewModelTest.kt
@@ -9,6 +9,7 @@ import com.escodro.task.presentation.fake.ScheduleAlarmFake
 import com.escodro.task.presentation.fake.UpdateTaskAsRepeatingFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
@@ -29,8 +30,13 @@ internal class TaskAlarmViewModelTest {
 
     private val alarmIntervalMapper = AlarmIntervalMapper()
 
-    private val viewModel =
-        TaskAlarmViewModel(scheduleAlarm, updateTaskAsRepeating, cancelAlarm, alarmIntervalMapper)
+    private val viewModel = TaskAlarmViewModel(
+        scheduleAlarmUseCase = scheduleAlarm,
+        updateTaskAsRepeatingUseCase = updateTaskAsRepeating,
+        cancelAlarmUseCase = cancelAlarm,
+        applicationScope = TestScope(coroutineTestRule.testDispatcher),
+        alarmIntervalMapper = alarmIntervalMapper
+    )
 
     @Test
     fun `test if alarm is set`() = runTest {

--- a/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/detail/TaskDetailViewModelTest.kt
@@ -15,6 +15,7 @@ import com.escodro.task.presentation.fake.UpdateTaskTitleFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
@@ -42,7 +43,8 @@ internal class TaskDetailViewModelTest {
         updateTaskDescription = updateDescription,
         updateTaskCategory = updateTaskCategory,
         taskMapper = taskMapper,
-        coroutineDebouncer = CoroutinesDebouncerFake()
+        coroutineDebouncer = CoroutinesDebouncerFake(),
+        applicationScope = TestScope(coroutineTestRule.testDispatcher)
     )
 
     @Test

--- a/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/list/TaskListViewModelTest.kt
@@ -10,6 +10,7 @@ import com.escodro.task.presentation.fake.UpdateTaskStatusFake
 import com.escodro.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -26,10 +27,13 @@ internal class TaskListViewModelTest {
 
     private val updateTaskStatus = UpdateTaskStatusFake()
 
+    private val mapper = TaskWithCategoryMapper(TaskMapper(AlarmIntervalMapper()), CategoryMapper())
+
     private val viewModel = TaskListViewModel(
-        loadUncompletedTasks,
-        updateTaskStatus,
-        TaskWithCategoryMapper(TaskMapper(AlarmIntervalMapper()), CategoryMapper())
+        loadAllTasksUseCase = loadUncompletedTasks,
+        updateTaskStatusUseCase = updateTaskStatus,
+        applicationScope = TestScope(coroutinesRule.testDispatcher),
+        taskWithCategoryMapper = mapper
     )
 
     @Before

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlin = "1.7.20"
 logging = "3.0.4"
 logback = "1.2.11"
 logcat = "0.1"
+serialization = "1.4.1"
 
 # AndroidX
 material = "1.7.0"
@@ -15,6 +16,7 @@ corektx = "1.9.0"
 playcore = "1.10.3"
 datastore = "1.0.0"
 glance = "1.0.0-alpha05"
+workmanager = "2.7.1"
 
 # Compose
 compose = "1.3.1"
@@ -64,6 +66,7 @@ kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 logging = { module = "io.github.microutils:kotlin-logging", version.ref = "logging" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logcat = { module = "com.squareup.logcat:logcat", version.ref = "logcat" }
+serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 # AndroidX
 androidx_material = { module = "com.google.android.material:material", version.ref = "material" }
@@ -71,6 +74,7 @@ androidx_corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" 
 androidx_playcore = { module = "com.google.android.play:core", version.ref = "playcore" }
 androidx_datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx_glance = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
+androidx_workmanager = { module = "androidx.work:work-runtime-ktx", version.ref = "workmanager" }
 
 compose_ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose_material = { module = "androidx.compose.material:material", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ constraint = "2.0.4"
 corektx = "1.9.0"
 playcore = "1.10.3"
 datastore = "1.0.0"
-glance = "1.0.0-alpha03"
+glance = "1.0.0-alpha05"
 
 # Compose
 compose = "1.3.1"

--- a/libraries/core/src/main/java/com/escodro/core/coroutines/ApplicationScope.kt
+++ b/libraries/core/src/main/java/com/escodro/core/coroutines/ApplicationScope.kt
@@ -1,0 +1,11 @@
+package com.escodro.core.coroutines
+
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.named
+
+/**
+ * Qualifier to represent the [kotlinx.coroutines.CoroutineScope] attached to the application
+ * lifecycle. This scope should be used in operations that must not be cancelled when the user
+ * changes screens.
+ */
+val ApplicationScope: Qualifier = named("AlkaaAppScope")

--- a/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
+++ b/libraries/test/src/main/java/com/escodro/test/CoroutineTestRule.kt
@@ -11,7 +11,7 @@ import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutineTestRule(
-    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 ) : TestWatcher() {
 
     override fun starting(description: Description) {


### PR DESCRIPTION
Due to the way that Glance works, new libraries were added in its module:

- WorkManager - Using Coroutines here is not enough since it is cancelled during the execution. Using WorkManager is a more reliable way to ensure that it will executed regardless of the Alkaa process state
- DataStore - In order to make the data persistently available and fit the Glance library, DataStore is needed
- KotlinX Serialization - Serializes the Alkaa data to fit the DataStore

Ideally, all this data logic would stay in the `:data` layer, however, once the processing here is too specific for the Glance logic, I decided to keep it here. Moving some logic across other layers would make it confusing and the use cases would need to know from which data source the data is available. There is no pretty solution for now.

The Glance feature also exposed some issues with the current ViewModelScope on Alkaa: as soon as the Composable is gone, the ViewModel dies and the execution is cancelled. This impacts all the Interactors that are called after the IO operation.

Based on Google's article and some discussion the solution was to create a new CoroutineScope and inject it in the following case:

> When the suspend function must be executed regardless of which screen the user is, use the injected scope. If the execution should be cancelled, then use viewModelScope.