### PR TITLE
👷 Update the GitHub actions to get the tag name for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ github.event.inputs.tagname }}"
           prerelease: false
           files: |
             ./app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
Oops... This information is now missing when not triggered by refs/tags