### PR TITLE
♻️ Remove duplicated CoroutineScope

### DIFF
--- a/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
+++ b/app/src/main/java/com/escodro/alkaa/di/AppModule.kt
@@ -3,9 +3,7 @@ package com.escodro.alkaa.di
 import com.escodro.alkaa.presentation.MainViewModel
 import com.escodro.alkaa.presentation.mapper.AppThemeOptionsMapper
 import com.escodro.core.coroutines.ApplicationScope
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.SupervisorJob
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
@@ -14,8 +12,6 @@ import org.koin.dsl.module
  * Application module.
  */
 val appModule = module {
-    factory { CoroutineScope(SupervisorJob()) }
-
     viewModelOf(::MainViewModel)
 
     factoryOf(::AppThemeOptionsMapper)

--- a/data/local/src/main/java/com/escodro/local/di/LocalModule.kt
+++ b/data/local/src/main/java/com/escodro/local/di/LocalModule.kt
@@ -1,5 +1,6 @@
 package com.escodro.local.di
 
+import com.escodro.core.coroutines.ApplicationScope
 import com.escodro.local.datasource.CategoryLocalDataSource
 import com.escodro.local.datasource.SearchLocalDataSource
 import com.escodro.local.datasource.TaskLocalDataSource
@@ -14,6 +15,7 @@ import com.escodro.repository.datasource.CategoryDataSource
 import com.escodro.repository.datasource.SearchDataSource
 import com.escodro.repository.datasource.TaskDataSource
 import com.escodro.repository.datasource.TaskWithCategoryDataSource
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -37,6 +39,6 @@ val localModule = module {
     factoryOf(::TaskWithCategoryMapper)
 
     // Providers
-    singleOf(::DatabaseProvider)
+    single { DatabaseProvider(context = androidContext(), coroutineScope = get(ApplicationScope)) }
     singleOf(::DaoProvider)
 }

--- a/features/alarm/build.gradle.kts
+++ b/features/alarm/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(projects.features.alarmApi)
     implementation(projects.libraries.core)
     implementation(projects.libraries.navigation)
+    implementation(projects.libraries.core)
     implementation(projects.domain)
 
     implementation(libs.kotlinx.coroutines.core)

--- a/features/alarm/src/main/java/com/escodro/alarm/TaskReceiver.kt
+++ b/features/alarm/src/main/java/com/escodro/alarm/TaskReceiver.kt
@@ -4,6 +4,7 @@ import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.escodro.core.coroutines.ApplicationScope
 import com.escodro.domain.usecase.alarm.RescheduleFutureAlarms
 import com.escodro.domain.usecase.alarm.ShowAlarm
 import com.escodro.domain.usecase.alarm.SnoozeAlarm
@@ -20,7 +21,7 @@ import org.koin.core.component.inject
  */
 internal class TaskReceiver : BroadcastReceiver(), KoinComponent {
 
-    private val coroutineScope: CoroutineScope by inject()
+    private val coroutineScope: CoroutineScope by inject(qualifier = ApplicationScope)
 
     private val completeTaskUseCase: CompleteTask by inject()
 

--- a/features/category/src/main/java/com/escodro/category/di/CategoryModule.kt
+++ b/features/category/src/main/java/com/escodro/category/di/CategoryModule.kt
@@ -17,7 +17,13 @@ import org.koin.dsl.module
  */
 val categoryModule = module {
     viewModelOf(::CategoryListViewModelImpl) bind CategoryListViewModel::class
-    viewModelOf(::CategoryAddViewModel)
+    viewModel {
+        CategoryAddViewModel(
+            addCategoryUseCase = get(),
+            applicationScope = get(ApplicationScope),
+            categoryMapper = get()
+        )
+    }
     viewModel {
         CategoryEditViewModel(
             loadCategoryUseCase = get(),

--- a/features/glance/build.gradle.kts
+++ b/features/glance/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(projects.domain)
     implementation(projects.libraries.navigation)
+    implementation(projects.libraries.core)
 
     implementation(libs.koin.android)
     implementation(libs.koin.compose)

--- a/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
+++ b/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
@@ -38,24 +38,26 @@ import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import com.escodro.core.coroutines.ApplicationScope
 import com.escodro.glance.R
 import com.escodro.glance.data.TaskListStateDefinition
 import com.escodro.glance.model.Task
 import com.escodro.navigation.DestinationDeepLink
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 internal class TaskListGlanceWidget : GlanceAppWidget(), KoinComponent {
 
-    private val coroutineScope: CoroutineScope = MainScope()
+    private val coroutineScope: CoroutineScope by inject(qualifier = ApplicationScope)
 
     /**
      * Custom implementation of [GlanceStateDefinition] to save and store data for this widget.
      */
-    override val stateDefinition: GlanceStateDefinition<ImmutableList<Task>> = TaskListStateDefinition
+    override val stateDefinition: GlanceStateDefinition<ImmutableList<Task>> =
+        TaskListStateDefinition
 
     @Composable
     override fun Content() {


### PR DESCRIPTION
While creating the new ApplicationScope, I didn't realized that a Scope was already in place. That was confusing, especially because both have the same goal. In order to make it better, one was removed and the one with qualifier is kept.