### PR TITLE
💚 Duplicate the scripts for running instrumented tests

### DIFF
--- a/.github/workflows/android_tests_aer.yml
+++ b/.github/workflows/android_tests_aer.yml
@@ -1,0 +1,57 @@
+name: Run instrumented tests (AER)
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-test:
+    runs-on: macos-latest
+    timeout-minutes: 80
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 24
+          profile: Galaxy Nexus
+          disable-animations: true
+          disk-size: 2000M
+          heap-size: 600M
+          script: |
+            adb logcat -c
+            adb logcat > logcat.txt &
+            ./gradlew connectedAndroidTest --stacktrace
+
+      - name: Save Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: test-results
+          path: |
+            /Users/runner/work/alkaa/alkaa/app/build/reports/androidTests/
+            ./logcat.txt
+          retention-days: 7

--- a/.github/workflows/android_tests_gmd.yml
+++ b/.github/workflows/android_tests_gmd.yml
@@ -1,4 +1,4 @@
-name: Run instrumented tests
+name: Run instrumented tests (GMD)
 
 on:
   push:
@@ -34,18 +34,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Run instrumented tests
-        # run: ./gradlew alkaaDevicesGroupDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 24
-          profile: Galaxy Nexus
-          disable-animations: true
-          disk-size: 2000M
-          heap-size: 600M
-          script: |
-            adb logcat -c
-            adb logcat > logcat.txt &
-            ./gradlew connectedAndroidTest --stacktrace
+        run: ./gradlew alkaaDevicesGroupDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
 
       - name: Save Test Results
         uses: actions/upload-artifact@v3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,17 +76,17 @@ android {
         managedDevices {
             devices {
                 add(
-                    create<ManagedVirtualDevice>("pixel2api30") {
+                    create<ManagedVirtualDevice>("pixel2api27") {
                         device = "Pixel 2"
-                        apiLevel = 30
-                        systemImageSource = "aosp-atd"
+                        apiLevel = 27
+                        systemImageSource = "aosp"
                     }
                 )
             }
             groups {
                 create("alkaaDevices").apply {
                     targetDevices.addAll(
-                        listOf(devices.getByName("pixel2api30"))
+                        listOf(devices.getByName("pixel2api27"))
                     )
                 }
                 unitTests.isReturnDefaultValues = true


### PR DESCRIPTION
I really like the Gradle Managed Devices, however, it seems more unreliable than the Android Emulator Runner by ReactiveCircus. For now, instead of going back and forth between them, both will run with similar configuration.