### PR TITLE
🐞 Fix Glance not working issue

### DIFF
--- a/features/glance/src/main/java/com/escodro/glance/data/TaskListStateDefinition.kt
+++ b/features/glance/src/main/java/com/escodro/glance/data/TaskListStateDefinition.kt
@@ -7,7 +7,6 @@ import androidx.datastore.dataStore
 import androidx.datastore.dataStoreFile
 import androidx.glance.state.GlanceStateDefinition
 import com.escodro.glance.model.Task
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -25,7 +24,7 @@ import java.io.OutputStream
  * layers would make it confusing and the use cases would need to know from which datasource the
  * data is available. There is no pretty solution for now.
  */
-internal object TaskListStateDefinition : GlanceStateDefinition<ImmutableList<Task>> {
+internal object TaskListStateDefinition : GlanceStateDefinition<List<Task>> {
 
     private const val DATA_STORE_FILENAME = "taskList"
 
@@ -34,7 +33,7 @@ internal object TaskListStateDefinition : GlanceStateDefinition<ImmutableList<Ta
     override suspend fun getDataStore(
         context: Context,
         fileKey: String,
-    ): DataStore<ImmutableList<Task>> =
+    ): DataStore<List<Task>> =
         context.datastore
 
     override fun getLocation(context: Context, fileKey: String): File =
@@ -44,15 +43,15 @@ internal object TaskListStateDefinition : GlanceStateDefinition<ImmutableList<Ta
      * Custom serializer to write and read data from [DataStore].
      */
     @OptIn(ExperimentalSerializationApi::class)
-    object TaskListSerializer : Serializer<ImmutableList<Task>> {
+    object TaskListSerializer : Serializer<List<Task>> {
 
-        override val defaultValue: ImmutableList<Task>
+        override val defaultValue: List<Task>
             get() = persistentListOf()
 
-        override suspend fun readFrom(input: InputStream): ImmutableList<Task> =
+        override suspend fun readFrom(input: InputStream): List<Task> =
             Json.decodeFromStream(input)
 
-        override suspend fun writeTo(t: ImmutableList<Task>, output: OutputStream) =
+        override suspend fun writeTo(t: List<Task>, output: OutputStream) =
             Json.encodeToStream(t, output)
     }
 }

--- a/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
+++ b/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
@@ -44,6 +44,7 @@ import com.escodro.glance.data.TaskListStateDefinition
 import com.escodro.glance.model.Task
 import com.escodro.navigation.DestinationDeepLink
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import org.koin.core.component.KoinComponent
@@ -56,12 +57,12 @@ internal class TaskListGlanceWidget : GlanceAppWidget(), KoinComponent {
     /**
      * Custom implementation of [GlanceStateDefinition] to save and store data for this widget.
      */
-    override val stateDefinition: GlanceStateDefinition<ImmutableList<Task>> =
+    override val stateDefinition: GlanceStateDefinition<List<Task>> =
         TaskListStateDefinition
 
     @Composable
     override fun Content() {
-        val taskList = currentState<ImmutableList<Task>>()
+        val taskList = currentState<List<Task>>().toImmutableList()
         Column(
             modifier = GlanceModifier
                 .fillMaxSize()


### PR DESCRIPTION
After moving from `List` to `ImmutableList` the Glance stopped working. It seems that serialization and/or encoding does not work very well with this library. For now, the Serializer was reverted to `List` and the conversion to ImmutableList will happen in the UI before rendering it.

I just found the following Exception on the stacktrace:
```
 java.util.concurrent.ExecutionException: kotlinx.serialization.SerializationException: Class 'SmallPersistentVector' is not registered for polymorphic serialization in the scope of 'ImmutableList'.
    Mark the base class as 'sealed' or register the serializer explicitly.
        at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
        at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
        at androidx.work.impl.WorkerWrapper$2.run(WorkerWrapper.java:311)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
        at java.lang.Thread.run(Thread.java:1012)
     Caused by: kotlinx.serialization.SerializationException: Class 'SmallPersistentVector' is not registered for polymorphic serialization in the scope of 'ImmutableList'.
```