### PR TITLE
🐞 Fix Snackbar never disappearing issue

### DIFF
--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -116,7 +117,12 @@ internal fun TaskListScaffold(
     val onShowSnackbar: (TaskWithCategory) -> Unit = { taskWithCategory ->
         coroutineScope.launch {
             val message = String.format(snackbarTitle, taskWithCategory.task.title)
-            when (snackbarHostState.showSnackbar(message, snackbarButton)) {
+            val snackbarResult = snackbarHostState.showSnackbar(
+                message = message,
+                actionLabel = snackbarButton,
+                duration = SnackbarDuration.Short,
+            )
+            when (snackbarResult) {
                 SnackbarResult.Dismissed -> {} // Do nothing
                 SnackbarResult.ActionPerformed -> taskHandler.onCheckedChange(taskWithCategory)
             }


### PR DESCRIPTION
In the new Snackbar API on Material You, if it does contain an `actionLabel` such as "Undo", the duration is set to "Indefinite". This was causing the Snackbar to never disappear. The API call was updated explicit passing the argument to show during a short period of time.