### PR TITLE
🎨 Add Navigation Rail to Home Composable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,8 @@ dependencies {
     implementation(libs.androidx.playcore)
     implementation(libs.koin.android)
 
+    implementation(libs.compose.windowsize)
+
     implementation(libs.bundles.compose)
     implementation(libs.kotlinx.collections.immutable)
 

--- a/app/src/androidTest/java/com/escodro/alkaa/CategoryFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/CategoryFlowTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.category.presentation.semantics.ColorKey
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.provider.DaoProvider
@@ -48,7 +49,7 @@ internal class CategoryFlowTest : KoinTest {
 
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph()
+                NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
             }
         }
         navigateToCategory()

--- a/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
@@ -28,7 +28,7 @@ internal class HomeScreenTest {
     fun setup() {
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph(windowSizeClass = WindowSizeClassFake.WindowSizeClassPhone)
+                NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
             }
         }
     }

--- a/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/HomeScreenTest.kt
@@ -1,12 +1,13 @@
 package com.escodro.alkaa
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.model.HomeSection
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.test.rule.DisableAnimationsRule
 import org.junit.Before
@@ -27,7 +28,7 @@ internal class HomeScreenTest {
     fun setup() {
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph()
+                NavGraph(windowSizeClass = WindowSizeClassFake.WindowSizeClassPhone)
             }
         }
     }
@@ -40,7 +41,7 @@ internal class HomeScreenTest {
             // Click on each item and validate the title
             composeTestRule.onNodeWithContentDescription(label = title, useUnmergedTree = true)
                 .performClick()
-            composeTestRule.onNodeWithText(title).assertExists()
+            composeTestRule.onAllNodesWithText(title)[0].assertExists()
         }
     }
 }

--- a/app/src/androidTest/java/com/escodro/alkaa/NotificationFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/NotificationFlowTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.core.extension.getNotificationManager
-import com.escodro.designsystem.AlkaaTheme
 import com.escodro.domain.usecase.alarm.ScheduleAlarm
 import com.escodro.local.model.AlarmInterval
 import com.escodro.local.model.Task
@@ -54,9 +54,7 @@ internal class NotificationFlowTest : KoinTest {
             daoProvider.getTaskDao().cleanTable()
         }
         composeTestRule.setContent {
-            AlkaaTheme {
-                NavGraph()
-            }
+            NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
         }
     }
 

--- a/app/src/androidTest/java/com/escodro/alkaa/PreferenceFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/PreferenceFlowTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.core.extension.getVersionName
 import com.escodro.test.rule.DisableAnimationsRule
 import org.junit.Before
@@ -29,7 +30,7 @@ internal class PreferenceFlowTest {
     @Before
     fun setup() {
         composeTestRule.setContent {
-            NavGraph()
+            NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
         }
         navigateToPreferences()
     }

--- a/app/src/androidTest/java/com/escodro/alkaa/SearchFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/SearchFlowTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.fake.FAKE_TASKS
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.provider.DaoProvider
 import com.escodro.test.extension.waitUntilNotExists
@@ -50,7 +51,7 @@ internal class SearchFlowTest : KoinTest {
 
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph()
+                NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
             }
         }
 

--- a/app/src/androidTest/java/com/escodro/alkaa/TaskFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/TaskFlowTest.kt
@@ -14,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.fake.CoroutinesDebouncerFake
 import com.escodro.alkaa.model.HomeSection
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.core.coroutines.CoroutineDebouncer
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.model.Category
@@ -65,7 +66,7 @@ internal class TaskFlowTest : KoinTest {
 
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph()
+                NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
             }
         }
     }
@@ -195,7 +196,7 @@ internal class TaskFlowTest : KoinTest {
         ).performClick()
 
         // Wait the list to be loaded
-        val taskTitle = context.getString(HomeSection.Tasks.title)
-        composeTestRule.waitUntilExists(hasText(taskTitle))
+        val searchTitle = context.getString(HomeSection.Search.title)
+        composeTestRule.waitUntilExists(hasText(searchTitle))
     }
 }

--- a/app/src/androidTest/java/com/escodro/alkaa/TaskListFlowTest.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/TaskListFlowTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.platform.app.InstrumentationRegistry
 import com.escodro.alkaa.navigation.NavGraph
+import com.escodro.alkaa.util.WindowSizeClassFake
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.local.model.Category
 import com.escodro.local.provider.DaoProvider
@@ -57,7 +58,7 @@ internal class TaskListFlowTest : KoinTest {
         }
         composeTestRule.setContent {
             AlkaaTheme {
-                NavGraph()
+                NavGraph(windowSizeClass = WindowSizeClassFake.Phone)
             }
         }
     }

--- a/app/src/androidTest/java/com/escodro/alkaa/util/WindowSizeClassFake.kt
+++ b/app/src/androidTest/java/com/escodro/alkaa/util/WindowSizeClassFake.kt
@@ -1,0 +1,12 @@
+package com.escodro.alkaa.util
+
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+internal object WindowSizeClassFake {
+
+    val Phone = WindowSizeClass.calculateFromSize(DpSize(400.dp, 900.dp))
+}

--- a/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
+++ b/app/src/main/java/com/escodro/alkaa/navigation/NavGraph.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -36,11 +37,12 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
 /**
  * Navigation Graph to control the Alkaa navigation.
  *
+ * @param windowSizeClass the window size class from current device
  * @param startDestination the start destination of the graph
  */
 @OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialNavigationApi::class)
 @Composable
-fun NavGraph(startDestination: String = Destinations.Home) {
+fun NavGraph(windowSizeClass: WindowSizeClass, startDestination: String = Destinations.Home) {
     val bottomSheetNavigator = rememberBottomSheetNavigator()
     val navController = rememberAnimatedNavController(bottomSheetNavigator)
     val context = LocalContext.current
@@ -49,7 +51,7 @@ fun NavGraph(startDestination: String = Destinations.Home) {
 
     ModalBottomSheetLayout(bottomSheetNavigator) {
         AnimatedNavHost(navController = navController, startDestination = startDestination) {
-            homeGraph(actions)
+            homeGraph(windowSizeClass, actions)
             taskGraph(actions)
             preferencesGraph(actions)
             categoryGraph(actions)
@@ -60,7 +62,7 @@ fun NavGraph(startDestination: String = Destinations.Home) {
 
 @OptIn(ExperimentalAnimationApi::class)
 @Suppress("MagicNumber")
-private fun NavGraphBuilder.homeGraph(actions: Actions) {
+private fun NavGraphBuilder.homeGraph(windowSizeClass: WindowSizeClass, actions: Actions) {
     composable(
         route = Destinations.Home,
         deepLinks = listOf(navDeepLink { uriPattern = DestinationDeepLink.HomePattern }),
@@ -78,6 +80,7 @@ private fun NavGraphBuilder.homeGraph(actions: Actions) {
         },
     ) {
         Home(
+            windowSizeClass = windowSizeClass,
             onTaskClick = actions.openTaskDetail,
             onAboutClick = actions.openAbout,
             onTrackerClick = actions.openTracker,

--- a/app/src/main/java/com/escodro/alkaa/presentation/AlkaaAppState.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/AlkaaAppState.kt
@@ -1,0 +1,42 @@
+package com.escodro.alkaa.presentation
+
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+
+/**
+ * Function to remember a [AlkaaAppState].
+ *
+ * @param windowSizeClass the window size class from current device
+ */
+@Composable
+fun rememberAlkaaAppState(windowSizeClass: WindowSizeClass): AlkaaAppState {
+    return remember(windowSizeClass) {
+        AlkaaAppState(windowSizeClass)
+    }
+}
+
+/**
+ * Alkaa App state.
+ *
+ * @property windowSizeClass the window size class from current device
+ */
+@Stable
+data class AlkaaAppState(private val windowSizeClass: WindowSizeClass) {
+
+    /**
+     * Verifies if the bottom bar should be shown.
+     */
+    val shouldShowBottomBar: Boolean
+        get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact ||
+            windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+
+    /**
+     * Verifies if the navigation rail should be shown.
+     */
+    val shouldShowNavRail: Boolean
+        get() = !shouldShowBottomBar
+}

--- a/app/src/main/java/com/escodro/alkaa/presentation/MainActivity.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/MainActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -18,6 +20,7 @@ import org.koin.androidx.viewmodel.ext.android.getViewModel
 /**
  * Main Alkaa Activity.
  */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 internal class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,7 +31,7 @@ internal class MainActivity : ComponentActivity() {
             updateTheme(isDarkTheme)
 
             AlkaaTheme(isDarkTheme = isDarkTheme) {
-                NavGraph()
+                NavGraph(windowSizeClass = calculateWindowSizeClass(activity = this))
             }
         }
     }

--- a/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
+++ b/app/src/main/java/com/escodro/alkaa/presentation/home/Home.kt
@@ -1,25 +1,41 @@
 package com.escodro.alkaa.presentation.home
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import com.escodro.alkaa.model.HomeSection
+import com.escodro.alkaa.presentation.AlkaaAppState
+import com.escodro.alkaa.presentation.rememberAlkaaAppState
 import com.escodro.category.presentation.list.CategoryListSection
 import com.escodro.designsystem.AlkaaTheme
 import com.escodro.preference.presentation.PreferenceSection
@@ -34,6 +50,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Suppress("LongParameterList")
 @Composable
 fun Home(
+    windowSizeClass: WindowSizeClass,
     onTaskClick: (Long) -> Unit,
     onAboutClick: () -> Unit,
     onTrackerClick: () -> Unit,
@@ -41,6 +58,7 @@ fun Home(
     onTaskSheetOpen: () -> Unit,
     onCategorySheetOpen: (Long?) -> Unit,
 ) {
+    val appState = rememberAlkaaAppState(windowSizeClass = windowSizeClass)
     val (currentSection, setCurrentSection) = rememberSaveable { mutableStateOf(HomeSection.Tasks) }
     val navItems = HomeSection.values().toList().toImmutableList()
 
@@ -56,6 +74,7 @@ fun Home(
 
     Crossfade(currentSection) { homeSection ->
         AlkaaHomeScaffold(
+            appState = appState,
             homeSection = homeSection,
             navItems = navItems,
             actions = actions,
@@ -63,32 +82,84 @@ fun Home(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun AlkaaHomeScaffold(
     homeSection: HomeSection,
     navItems: ImmutableList<HomeSection>,
     actions: HomeActions,
+    appState: AlkaaAppState,
 ) {
     Scaffold(
         topBar = {
             AlkaaTopBar(currentSection = homeSection)
         },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         content = { paddingValues ->
-            AlkaaContent(
-                homeSection = homeSection,
-                modifier = Modifier.padding(paddingValues),
-                actions = actions,
-            )
+            Row(
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .consumedWindowInsets(paddingValues)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal),
+                    ),
+            ) {
+                if (appState.shouldShowNavRail) {
+                    AlkaaNavRail(
+                        currentSection = homeSection,
+                        onSectionSelect = actions.setCurrentSection,
+                        items = navItems,
+                        modifier = Modifier.safeDrawingPadding(),
+                    )
+                }
+                Column(Modifier.fillMaxSize()) {
+                    AlkaaContent(
+                        homeSection = homeSection,
+                        modifier = Modifier,
+                        actions = actions,
+                    )
+                }
+            }
         },
         bottomBar = {
-            AlkaaBottomNav(
-                currentSection = homeSection,
-                onSectionSelect = actions.setCurrentSection,
-                items = navItems,
-            )
+            if (appState.shouldShowBottomBar) {
+                AlkaaBottomNav(
+                    currentSection = homeSection,
+                    onSectionSelect = actions.setCurrentSection,
+                    items = navItems,
+                )
+            }
         },
     )
+}
+
+@Composable
+private fun AlkaaNavRail(
+    currentSection: HomeSection,
+    onSectionSelect: (HomeSection) -> Unit,
+    items: ImmutableList<HomeSection>,
+    modifier: Modifier = Modifier,
+) {
+    NavigationRail(modifier = modifier) {
+        items.forEach { section ->
+            val selected = section == currentSection
+            NavigationRailItem(
+                selected = selected,
+                onClick = { onSectionSelect(section) },
+                alwaysShowLabel = true,
+                icon = { Icon(imageVector = section.icon, contentDescription = null) },
+                label = { Text(stringResource(id = section.title)) },
+                colors = NavigationRailItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            )
+        }
+    }
 }
 
 @Composable
@@ -110,7 +181,6 @@ private fun AlkaaContent(
             CategoryListSection(
                 modifier = modifier,
                 onShowBottomSheet = actions.onCategorySheetOpen,
-
             )
         HomeSection.Settings ->
             PreferenceSection(
@@ -145,36 +215,21 @@ private fun AlkaaBottomNav(
     BottomAppBar(containerColor = MaterialTheme.colorScheme.background) {
         items.forEach { section ->
             val selected = section == currentSection
-            val colorState = animateColorAsState(
-                if (selected) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.outline
-                },
-            )
-            AlkaaBottomIcon(
-                section = section,
-                tint = colorState.value,
-                onSectionSelect = onSectionSelect,
-                modifier = Modifier.weight(1f),
+            val title = stringResource(id = section.title)
+            NavigationBarItem(
+                selected = selected,
+                onClick = { onSectionSelect(section) },
+                icon = { Icon(imageVector = section.icon, contentDescription = title) },
+                label = { Text(title) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
             )
         }
-    }
-}
-
-@Composable
-private fun AlkaaBottomIcon(
-    section: HomeSection,
-    tint: Color,
-    onSectionSelect: (HomeSection) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val title = stringResource(section.title)
-    IconButton(
-        onClick = { onSectionSelect(section) },
-        modifier = modifier,
-    ) {
-        Icon(imageVector = section.icon, tint = tint, contentDescription = title)
     }
 }
 

--- a/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/main/java/com/escodro/task/presentation/list/TaskList.kt
@@ -5,9 +5,8 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ThumbUp
@@ -184,23 +183,20 @@ private fun TaskListContent(
     onItemClick: (Long) -> Unit,
     onCheckedChange: (TaskWithCategory) -> Unit,
 ) {
-    BoxWithConstraints(modifier = Modifier.padding(start = 8.dp, end = 8.dp)) {
-        val cellCount = if (this.maxHeight > maxWidth) 1 else 2
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(cellCount),
-            contentPadding = PaddingValues(bottom = 48.dp),
-        ) {
-            items(
-                items = taskList,
-                itemContent = { task ->
-                    TaskItem(
-                        task = task,
-                        onItemClick = onItemClick,
-                        onCheckedChange = onCheckedChange,
-                    )
-                },
-            )
-        }
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 48.dp),
+        modifier = Modifier.padding(start = 8.dp, end = 8.dp),
+    ) {
+        items(
+            items = taskList,
+            itemContent = { task ->
+                TaskItem(
+                    task = task,
+                    onItemClick = onItemClick,
+                    onCheckedChange = onCheckedChange,
+                )
+            },
+        )
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ compose_viewmodel = "2.5.1"
 compose_activity = "1.6.1"
 compose_material3 = "1.0.1"
 compose_icons = "1.3.1"
+compose_windowsize = "1.0.1"
 
 # Room
 room = "2.5.0"
@@ -104,6 +105,7 @@ compose_material3 = { module = "androidx.compose.material3:material3", version.r
 compose_uitest = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }
 compose_junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose_manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+compose_windowsize = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "compose_windowsize" }
 
 # Room
 androidx_room_runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
@@ -149,5 +151,5 @@ composetest = ["compose.uitest", "compose.junit4", "compose.manifest"]
 [plugins]
 kotlin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-dependencyanalysis = {id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyanalysis"}
+dependencyanalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyanalysis" }
 


### PR DESCRIPTION
After some initial efforts on #225, now it's time for Alkaa to properly support different form factors. The first step is implementing a [NavigationRail](https://m3.material.io/components/navigation-rail/overview) to better accommodate the navigation icons on the screen.

![image](https://user-images.githubusercontent.com/2267495/215134829-8686c885-32c7-403c-9162-a6f5b319d5f0.png)

The next PRs improve the experience by using multiple panes and better using the empty space on the screen.

| ![Screenshot_1674835538](https://user-images.githubusercontent.com/2267495/215134161-58b12c2d-0bbf-4051-a9f0-6272b7e81e30.png) | ![Screenshot_1674835520](https://user-images.githubusercontent.com/2267495/215134155-dfd476fc-8e1a-4cd2-a68f-65fac03f8db3.png)| ![Screenshot_1674835533](https://user-images.githubusercontent.com/2267495/215134158-59fbe3d1-34af-4ab2-b92d-16a9089dda47.png)  | ![Screenshot_1674835547](https://user-images.githubusercontent.com/2267495/215134162-ec6a8b93-d74e-4e03-aec2-0726e84697ce.png) |
| ------------- | ------------- | ------------- | ------------- |
| Phone  | Foldable  | Tablet  | ChromeOS  |

_This implementation was based on the [Now In Android ](https://github.com/android/nowinandroid)repo by @android._





