### PR TITLE
🔧 Update `gradle.properties` to allow native cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,3 @@ kotlin.jvm.target.validation.mode=IGNORE
 org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.native.cacheKind=none


### PR DESCRIPTION
One more of the configs that was added but not sure why. By removing it, the cache and build speed will be faster, based on the warnings. So far, no issues with the iOS app.