### PR TITLE
🏠 Implement the Home UI-feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
         classpath(libs.kotlin.gradle.plugin)
         classpath(libs.aboutlibraries.plugin)
         classpath(libs.kotlin.atomicfu)
+        classpath(libs.moko.resources.generator)
     }
 }
 

--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -24,6 +24,8 @@ kotlin {
         implementation(libs.moko.mvvm.compose)
     }
 
+    // Explicit dependency due to Moko issues with Kotlin 1.9.0
+    // https://github.com/icerockdev/moko-resources/issues/531
     sourceSets {
         val commonMain by getting
         val androidMain by getting {

--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -1,0 +1,38 @@
+import extension.commonDependencies
+import extension.setFrameworkBaseName
+
+plugins {
+    id("com.escodro.multiplatform")
+    alias(libs.plugins.compose)
+    id(libs.plugins.moko.multiplatform.resources.get().pluginId) // Use version from classpath
+}
+
+kotlin {
+    setFrameworkBaseName("home")
+
+    commonDependencies {
+        implementation(projects.domain)
+        implementation(projects.resources)
+
+        implementation(compose.runtime)
+        implementation(compose.materialIconsExtended)
+        implementation(compose.material)
+        implementation(compose.material3)
+        implementation(libs.koin.compose.jb)
+        implementation(libs.kotlinx.collections.immutable)
+        implementation(libs.moko.resources.compose)
+        implementation(libs.moko.mvvm.compose)
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val androidMain by getting {
+            dependsOn(commonMain)
+        }
+    }
+}
+
+android {
+    namespace = "com.escodro.home"
+}
+

--- a/features/home/src/commonMain/kotlin/com/escodro/home/presentation/Home.kt
+++ b/features/home/src/commonMain/kotlin/com/escodro/home/presentation/Home.kt
@@ -1,0 +1,212 @@
+package com.escodro.home.presentation
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * Alkaa Home screen.
+ */
+@Suppress("LongParameterList")
+@Composable
+fun Home(
+    onTaskClick: (Long) -> Unit,
+    onAboutClick: () -> Unit,
+    onTrackerClick: () -> Unit,
+    onOpenSourceClick: () -> Unit,
+    onTaskSheetOpen: () -> Unit,
+    onCategorySheetOpen: (Long?) -> Unit,
+) {
+    val (currentSection, setCurrentSection) = rememberSaveable { mutableStateOf(HomeSection.Tasks) }
+    val navItems = HomeSection.values().toList().toImmutableList()
+
+    val actions = remember {
+        object : HomeActions {
+            override val onTaskClick = onTaskClick
+            override val onAboutClick = onAboutClick
+            override val onTrackerClick = onTrackerClick
+            override val onOpenSourceClick = onOpenSourceClick
+            override val onTaskSheetOpen = onTaskSheetOpen
+            override val onCategorySheetOpen = onCategorySheetOpen
+            override val setCurrentSection = setCurrentSection
+        }
+    }
+
+    Crossfade(currentSection) { homeSection ->
+        AlkaaHomeScaffold(
+            homeSection = homeSection,
+            navItems = navItems,
+            actions = actions,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AlkaaHomeScaffold(
+    homeSection: HomeSection,
+    navItems: ImmutableList<HomeSection>,
+    actions: HomeActions,
+) {
+    Scaffold(
+        topBar = {
+            AlkaaTopBar(currentSection = homeSection)
+        },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        content = { paddingValues ->
+            Row(
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .consumeWindowInsets(paddingValues)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal),
+                    ),
+            ) {
+                Column(Modifier.fillMaxSize()) {
+                    AlkaaContent(
+                        homeSection = homeSection,
+                        modifier = Modifier,
+                        actions = actions,
+                    )
+                }
+            }
+        },
+        bottomBar = {
+            AlkaaBottomNav(
+                currentSection = homeSection,
+                onSectionSelect = actions.setCurrentSection,
+                items = navItems,
+            )
+        },
+    )
+}
+
+@Composable
+private fun AlkaaNavRail(
+    currentSection: HomeSection,
+    onSectionSelect: (HomeSection) -> Unit,
+    items: ImmutableList<HomeSection>,
+    modifier: Modifier = Modifier,
+) {
+    NavigationRail(modifier = modifier) {
+        items.forEach { section ->
+            val selected = section == currentSection
+            NavigationRailItem(
+                selected = selected,
+                onClick = { onSectionSelect(section) },
+                alwaysShowLabel = true,
+                icon = { Icon(imageVector = section.icon, contentDescription = null) },
+                label = { Text(stringResource(section.title)) },
+                colors = NavigationRailItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlkaaContent(
+    homeSection: HomeSection,
+    actions: HomeActions,
+    modifier: Modifier = Modifier,
+) {
+    when (homeSection) {
+        HomeSection.Tasks -> {}
+        // TaskListSection(
+        //     modifier = modifier,
+        //     onItemClick = actions.onTaskClick,
+        //     onBottomShow = actions.onTaskSheetOpen,
+        // )
+
+        HomeSection.Search -> {}
+        // SearchSection(modifier = modifier, onItemClick = actions.onTaskClick)
+
+        HomeSection.Categories -> {}
+        // CategoryListSection(
+        //     modifier = modifier,
+        //     onShowBottomSheet = actions.onCategorySheetOpen,
+        // )
+
+        HomeSection.Settings -> {}
+        // PreferenceSection(
+        //     modifier = modifier,
+        //     onAboutClick = actions.onAboutClick,
+        //     onTrackerClick = actions.onTrackerClick,
+        //     onOpenSourceClick = actions.onOpenSourceClick,
+        // )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlkaaTopBar(currentSection: HomeSection) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(
+                style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Light),
+                text = stringResource(currentSection.title),
+                color = MaterialTheme.colorScheme.tertiary,
+            )
+        },
+    )
+}
+
+@Composable
+private fun AlkaaBottomNav(
+    currentSection: HomeSection,
+    onSectionSelect: (HomeSection) -> Unit,
+    items: ImmutableList<HomeSection>,
+) {
+    BottomAppBar(containerColor = MaterialTheme.colorScheme.background) {
+        items.forEach { section ->
+            val selected = section == currentSection
+            val title = section.title
+            NavigationBarItem(
+                selected = selected,
+                onClick = { onSectionSelect(section) },
+                icon = {
+                    Icon(
+                        imageVector = section.icon,
+                        contentDescription = stringResource(title),
+                    )
+                },
+                label = { Text(stringResource(title)) },
+            )
+        }
+    }
+}

--- a/features/home/src/commonMain/kotlin/com/escodro/home/presentation/HomeActions.kt
+++ b/features/home/src/commonMain/kotlin/com/escodro/home/presentation/HomeActions.kt
@@ -1,0 +1,41 @@
+package com.escodro.home.presentation
+
+/**
+ * Actions to be performed on the Home screen.
+ */
+internal interface HomeActions {
+    /**
+     * Action to be performed when a task is clicked.
+     */
+    val onTaskClick: (Long) -> Unit
+
+    /**
+     * Action to be performed when the about item is clicked.
+     */
+    val onAboutClick: () -> Unit
+
+    /**
+     * Action to be performed when the task tracker item is clicked.
+     */
+    val onTrackerClick: () -> Unit
+
+    /**
+     * Action to be performed when the open source item is clicked.
+     */
+    val onOpenSourceClick: () -> Unit
+
+    /**
+     * Action to be performed when the task bottom sheet is opened.
+     */
+    val onTaskSheetOpen: () -> Unit
+
+    /**
+     * Action to be performed when the category bottom sheet is opened.
+     */
+    val onCategorySheetOpen: (Long?) -> Unit
+
+    /**
+     * Action to be performed when the current bottom nav section is changed.
+     */
+    val setCurrentSection: (HomeSection) -> Unit
+}

--- a/features/home/src/commonMain/kotlin/com/escodro/home/presentation/HomeSection.kt
+++ b/features/home/src/commonMain/kotlin/com/escodro/home/presentation/HomeSection.kt
@@ -1,0 +1,26 @@
+package com.escodro.home.presentation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bookmark
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.MoreHoriz
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.escodro.resources.MR
+import dev.icerock.moko.resources.StringResource
+
+/**
+ * Enum to represent the sections available in the bottom app bar.
+ *
+ * @property title title to be shown in top app bar.
+ * @property icon icon to be shown in the bottom app bar
+ */
+internal enum class HomeSection(
+    val title: StringResource,
+    val icon: ImageVector,
+) {
+    Tasks(MR.strings.home_title_tasks, Icons.Outlined.Check),
+    Search(MR.strings.home_title_search, Icons.Outlined.Search),
+    Categories(MR.strings.home_title_categories, Icons.Outlined.Bookmark),
+    Settings(MR.strings.home_title_settings, Icons.Outlined.MoreHoriz),
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ sqldelight = "2.0.0"
 
 # Moko
 moko = "0.16.1"
+moko_resources = "0.23.0"
 
 # AtomicFU
 atomicfu = "0.22.0"
@@ -145,6 +146,10 @@ sqldelight_coroutines = { module = "app.cash.sqldelight:coroutines-extensions", 
 
 # Moko
 moko_mvvm_core = { module = "dev.icerock.moko:mvvm-core", version.ref = "moko" }
+moko_mvvm_compose = { module = "dev.icerock.moko:mvvm-flow-compose", version.ref = "moko" }
+moko_resources_generator = { module = "dev.icerock.moko:resources-generator", version.ref = "moko_resources" }
+moko_resources_core = { module = "dev.icerock.moko:resources", version.ref = "moko_resources" }
+moko_resources_compose = { module = "dev.icerock.moko:resources-compose", version.ref = "moko_resources" }
 
 # Test
 test_junit = { module = "junit:junit", version.ref = "test_junit" }
@@ -176,5 +181,6 @@ kotlin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dependencyanalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyanalysis" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-compose = {id = "org.jetbrains.compose", version.ref = "jb_compose_compiler" }
+compose = { id = "org.jetbrains.compose", version.ref = "jb_compose_compiler" }
+moko_multiplatform_resources = { id = "dev.icerock.mobile.multiplatform-resources" }
 

--- a/ios-app/alkaa.xcodeproj/project.pbxproj
+++ b/ios-app/alkaa.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D8AA52062A8FABB700A0D1F2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D8AA52082A8FABB800A0D1F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D8AA520B2A8FABB800A0D1F2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		D8F635C82AA79E6E00431055 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +60,7 @@
 		D8AA52032A8FABB700A0D1F2 /* alkaa */ = {
 			isa = PBXGroup;
 			children = (
+				D8F635C82AA79E6E00431055 /* Info.plist */,
 				D8AA52042A8FABB700A0D1F2 /* alkaaApp.swift */,
 				D8AA52062A8FABB700A0D1F2 /* ContentView.swift */,
 				D8AA52082A8FABB800A0D1F2 /* Assets.xcassets */,
@@ -320,6 +322,9 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = alkaa/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_LSApplicationCategoryType = en;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -357,6 +362,9 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = alkaa/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_LSApplicationCategoryType = en;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios-app/alkaa.xcodeproj/project.pbxproj
+++ b/ios-app/alkaa.xcodeproj/project.pbxproj
@@ -82,10 +82,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D8AA520F2A8FABB800A0D1F2 /* Build configuration list for PBXNativeTarget "alkaa" */;
 			buildPhases = (
-				D8AA52122A8FABD000A0D1F2 /* ShellScript */,
+				D8AA52122A8FABD000A0D1F2 /* Connect iOS and KMP */,
 				D8AA51FD2A8FABB700A0D1F2 /* Sources */,
 				D8AA51FE2A8FABB700A0D1F2 /* Frameworks */,
 				D8AA51FF2A8FABB700A0D1F2 /* Resources */,
+				D8C453972AA36D2D006C2397 /* Copy Moko Resources */,
 			);
 			buildRules = (
 			);
@@ -142,7 +143,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		D8AA52122A8FABD000A0D1F2 /* ShellScript */ = {
+		D8AA52122A8FABD000A0D1F2 /* Connect iOS and KMP */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -151,6 +152,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Connect iOS and KMP";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -158,6 +160,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+		};
+		D8C453972AA36D2D006C2397 /* Copy Moko Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Moko Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/../gradlew\" -p \"$SRCROOT/../\" :shared:copyFrameworkResourcesToApp \\\n    -Pmoko.resources.PLATFORM_NAME=\"$PLATFORM_NAME\" \\\n    -Pmoko.resources.CONFIGURATION=\"$CONFIGURATION\" \\\n    -Pmoko.resources.ARCHS=\"$ARCHS\" \\\n    -Pmoko.resources.BUILT_PRODUCTS_DIR=\"$BUILT_PRODUCTS_DIR\" \\\n    -Pmoko.resources.CONTENTS_FOLDER_PATH=\"$CONTENTS_FOLDER_PATH\" \n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios-app/alkaa/Info.plist
+++ b/ios-app/alkaa/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleLocalizations</key><array>
+<string>en-US</string>
+<string>pt-BR</string>
+</array>
+</dict>
+</plist>

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -31,3 +31,14 @@ android {
 multiplatformResources {
     multiplatformResourcesPackage = "com.escodro.resources"
 }
+
+// Define explicit dependency for Moko resources
+// https://github.com/icerockdev/moko-resources/issues/421
+afterEvaluate {
+    tasks.named("iosSimulatorArm64ProcessResources") {
+        dependsOn("generateMRcommonMain")
+    }
+    tasks.named("iosX64ProcessResources") {
+        dependsOn("generateMRcommonMain")
+    }
+}

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -1,0 +1,31 @@
+import extension.commonDependencies
+import extension.setFrameworkBaseName
+
+plugins {
+    id("com.escodro.multiplatform")
+    id(libs.plugins.moko.multiplatform.resources.get().pluginId) // Use version from classpath
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    setFrameworkBaseName("resources")
+
+    commonDependencies {
+        implementation(libs.moko.resources.core)
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val androidMain by getting {
+            dependsOn(commonMain)
+        }
+    }
+}
+
+android {
+    namespace = "com.escodro.resources"
+}
+
+multiplatformResources {
+    multiplatformResourcesPackage = "com.escodro.resources"
+}

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -14,6 +14,8 @@ kotlin {
         implementation(libs.moko.resources.core)
     }
 
+    // Explicit dependency due to Moko issues with Kotlin 1.9.0
+    // https://github.com/icerockdev/moko-resources/issues/531
     sourceSets {
         val commonMain by getting
         val androidMain by getting {

--- a/resources/src/commonMain/resources/MR/base/strings.xml
+++ b/resources/src/commonMain/resources/MR/base/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+
+    <!-- AppTopBar -->
+    <string name="home_title_tasks">Tasks</string>
+    <string name="home_title_search">Search</string>
+    <string name="home_title_categories">Categories</string>
+    <string name="home_title_settings">More</string>
+
+</resources>

--- a/resources/src/commonMain/resources/MR/pt-br/strings.xml
+++ b/resources/src/commonMain/resources/MR/pt-br/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="home_title_tasks">Tarefas</string>
+    <string name="home_title_search">Pesquisar</string>
+    <string name="home_title_categories">Categorias</string>
+    <string name="home_title_settings">Mais</string>
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,9 @@ include(":libraries:di")
 
 include(":domain")
 include(":shared")
+include(":resources")
+
+include(":features:home")
 
 pluginManagement {
     repositories {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -4,6 +4,7 @@ import extension.commonTestDependencies
 plugins {
     id("com.escodro.multiplatform")
     alias(libs.plugins.compose)
+    id(libs.plugins.moko.multiplatform.resources.get().pluginId) // Use version from classpath
 }
 
 kotlin {
@@ -30,16 +31,32 @@ kotlin {
         implementation(projects.libraries.coroutines)
         implementation(projects.libraries.designsystem)
 
-        implementation(libs.koin.core)
+        implementation(projects.features.home)
+
+        implementation(projects.resources)
+
         implementation(projects.domain)
         implementation(compose.runtime)
         implementation(compose.material3)
+        implementation(libs.koin.core)
+        implementation(libs.moko.resources.core)
     }
     commonTestDependencies {
         implementation(kotlin("test"))
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val androidMain by getting {
+            dependsOn(commonMain)
+        }
     }
 }
 
 android {
     namespace = "com.escodro.shared"
+}
+
+multiplatformResources {
+    multiplatformResourcesPackage = "com.escodro.alkaa"
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
         implementation(kotlin("test"))
     }
 
+    // Explicit dependency due to Moko issues with Kotlin 1.9.0
+    // https://github.com/icerockdev/moko-resources/issues/531
     sourceSets {
         val commonMain by getting
         val androidMain by getting {

--- a/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
+++ b/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
@@ -1,14 +1,8 @@
 package com.escodro.shared
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import com.escodro.designsystem.AlkaaTheme
+import com.escodro.home.presentation.Home
 
 @Composable
 fun AlkaaMultiplatformApp() {
@@ -19,10 +13,12 @@ fun AlkaaMultiplatformApp() {
 
 @Composable
 private fun HelloWorld() {
-    Box(
-        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(text = "Hello World!", color = MaterialTheme.colorScheme.onBackground)
-    }
+    Home(
+        onTaskClick = {},
+        onAboutClick = {},
+        onTrackerClick = {},
+        onOpenSourceClick = {},
+        onTaskSheetOpen = {},
+        onCategorySheetOpen = {},
+    )
 }


### PR DESCRIPTION
A new module (`:features:home`) was created to hold the home feature from Android's `:app` module. This module will be responsible for the main Scaffold and basic navigation between tabs.

In the previous structure, this code was inside Android's `:app` but in order to make it multiplatform, we need a dedicated module. We could put the logic on `shared`, but my goal for that module is just to be an "umbrella" with a small setup.

Also, Moko Resources was added to handle the resources on all platforms.