### PR TITLE
🔧 Fix check reports issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ out/
 # Gradle files
 .gradle/
 build/
-*(org.gradle.api.file.Directory*
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         checkDependencies = true
 
         lintConfig = file("${rootDir}/config/filters/lint.xml")
-        htmlOutput = file("${layout.buildDirectory}/reports/lint.html")
+        htmlOutput = layout.buildDirectory.file("reports/lint.html").get().asFile
 
         project.tasks.check.dependsOn("lint")
     }

--- a/plugins/src/main/java/quality/ktlint.gradle.kts
+++ b/plugins/src/main/java/quality/ktlint.gradle.kts
@@ -1,9 +1,6 @@
 package quality
 
 import ktlint
-import org.gradle.api.artifacts.VersionCatalog
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.getByType
 
 val ktlint: Configuration by configurations.creating
 val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -17,9 +14,10 @@ tasks {
         description = "Check Kotlin code style."
         classpath = ktlint
         mainClass.set("com.pinterest.ktlint.Main")
+        val buildDir = layout.buildDirectory.get().asFile.path
         args(
             "src/**/*.kt", "--reporter=plain", "--reporter=checkstyle," +
-                "output=${layout.buildDirectory}/reports/ktlint.xml"
+                "output=${buildDir}/reports/ktlint.xml"
         )
     }
 


### PR DESCRIPTION
A silly mistake while migrating to Gradle 8 and `buildDir` was deprecated. Turns out that `layout.buildDirectory` is not a simple String replacement with the new path.

https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir