### PR TITLE
✨ Re-enable the ability of navigating using deep links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ android {
 
 dependencies {
     implementation(projects.shared)
+    implementation(projects.libraries.navigation)
 
     implementation(platform(libs.compose.bom))
 

--- a/app/src/main/java/com/escodro/alkaa/MainActivity.kt
+++ b/app/src/main/java/com/escodro/alkaa/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.WindowCompat
+import com.escodro.navigation.NavigationAction
 import com.escodro.shared.MainView
 
 /**
@@ -21,6 +22,7 @@ internal class MainActivity : ComponentActivity() {
 
         setContent {
             MainView(
+                navigationAction = getNavigationAction(),
                 onThemeUpdate = ::updateTheme,
             )
         }
@@ -35,6 +37,10 @@ internal class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge(statusBarStyle = systemBarStyle, navigationBarStyle = systemBarStyle)
     }
+
+    private fun getNavigationAction(): NavigationAction =
+        intent.extras?.getParcelable(NavigationAction.EXTRA_DESTINATION)
+            ?: NavigationAction.Home
 }
 
 /**

--- a/features/glance/build.gradle.kts
+++ b/features/glance/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(projects.domain)
     implementation(projects.libraries.navigation)
     implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
 
     implementation(libs.koin.core)
     implementation(libs.androidx.glance)

--- a/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
+++ b/features/glance/src/main/java/com/escodro/glance/presentation/TaskListGlanceWidget.kt
@@ -1,7 +1,6 @@
 package com.escodro.glance.presentation
 
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
@@ -44,6 +43,7 @@ import androidx.glance.text.TextStyle
 import com.escodro.glance.R
 import com.escodro.glance.data.TaskListStateDefinition
 import com.escodro.glance.model.Task
+import com.escodro.navigation.AndroidDestinations
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -81,7 +81,7 @@ internal class TaskListGlanceWidget : GlanceAppWidget() {
                         provider = ImageProvider(R.drawable.ic_alkaa_icon),
                         contentDescription = context.getString(R.string.glance_app_icon_content_description),
                         modifier = GlanceModifier.size(32.dp)
-                            .clickable(actionStartActivity(getHomeIntent())),
+                            .clickable(actionStartActivity(AndroidDestinations.homeIntent())),
                     )
                     Spacer(modifier = GlanceModifier.width(12.dp))
                     Text(
@@ -149,7 +149,7 @@ internal class TaskListGlanceWidget : GlanceAppWidget() {
     private fun TaskItem(task: Task, modifier: GlanceModifier = GlanceModifier) {
         Row(
             modifier = modifier.padding(vertical = 2.dp).fillMaxWidth()
-                .clickable(actionStartActivity(getTaskIntent())),
+                .clickable(actionStartActivity(AndroidDestinations.taskDetail(task.id))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             CheckBox(
@@ -172,10 +172,4 @@ internal class TaskListGlanceWidget : GlanceAppWidget() {
             )
         }
     }
-
-    private fun getHomeIntent(): Intent =
-        Intent(Intent.ACTION_VIEW) // TODO
-
-    private fun getTaskIntent(): Intent =
-        Intent(Intent.ACTION_VIEW) // TODO
 }

--- a/libraries/navigation/build.gradle.kts
+++ b/libraries/navigation/build.gradle.kts
@@ -3,6 +3,7 @@ import extension.setFrameworkBaseName
 
 plugins {
     id("com.escodro.multiplatform")
+    id("kotlin-parcelize")
     alias(libs.plugins.compose)
 }
 
@@ -12,9 +13,11 @@ kotlin {
     commonDependencies {
         implementation(compose.runtime)
         implementation(compose.material)
+
         api(libs.voyager.navigator)
         api(libs.voyager.bottomsheet)
 
+        implementation(libs.moko.parcelize)
     }
 }
 

--- a/libraries/navigation/src/androidMain/kotlin/com/escodro/navigation/AndroidDestinations.kt
+++ b/libraries/navigation/src/androidMain/kotlin/com/escodro/navigation/AndroidDestinations.kt
@@ -1,0 +1,31 @@
+package com.escodro.navigation
+
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * Destinations specifically for the Android platform since it requires [Intent] to navigate between
+ * screens in some flows, such as notifications and widgets.
+ */
+object AndroidDestinations {
+
+    /**
+     * Returns the [Intent] to the home screen.
+     */
+    fun homeIntent(): Intent = Intent(Intent.ACTION_VIEW, Uri.parse(HOME_DEEP_LINK))
+
+    /**
+     * Returns the [Intent] to the task detail screen.
+     *
+     * @param taskId the task id to be shown
+     */
+    fun taskDetail(taskId: Long): Intent = homeIntent().apply {
+        val action = NavigationAction.TaskDetail(taskId)
+        putExtra(NavigationAction.EXTRA_DESTINATION, action)
+    }
+
+    /**
+     * Main activity's deep link.
+     */
+    private const val HOME_DEEP_LINK = "app://com.escodro.alkaa"
+}

--- a/libraries/navigation/src/commonMain/kotlin/com/escodro/navigation/NavigationAction.kt
+++ b/libraries/navigation/src/commonMain/kotlin/com/escodro/navigation/NavigationAction.kt
@@ -1,0 +1,32 @@
+package com.escodro.navigation
+
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+
+/**
+ * Navigation action to be executed using deep links.
+ */
+sealed interface NavigationAction : Parcelable {
+
+    /**
+     * Home screen navigation action.
+     */
+    @Parcelize
+    data object Home : NavigationAction
+
+    /**
+     * Task detail screen navigation action.
+     *
+     * @param taskId the task id to be shown
+     */
+    @Parcelize
+    data class TaskDetail(val taskId: Long) : NavigationAction
+
+    companion object {
+
+        /**
+         * Key to be used to retrieve the [NavigationAction] from the platform-specific map.
+         */
+        const val EXTRA_DESTINATION = "destination"
+    }
+}

--- a/shared/src/androidMain/kotlin/com/escodro/shared/Main.android.kt
+++ b/shared/src/androidMain/kotlin/com/escodro/shared/Main.android.kt
@@ -3,7 +3,20 @@ package com.escodro.shared
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.escodro.navigation.NavigationAction
 
+/**
+ * Main view of the application.
+ *
+ * @param navigationAction the navigation action to be consumed when the app is open
+ * @param onThemeUpdate the callback to be called when the theme is updated
+ */
 @Composable
-fun MainView(onThemeUpdate: (isDarkTheme: Boolean) -> Unit = {}) =
-    AlkaaMultiplatformApp(modifier = Modifier.imePadding(), onThemeUpdate = onThemeUpdate)
+fun MainView(
+    navigationAction: NavigationAction,
+    onThemeUpdate: (isDarkTheme: Boolean) -> Unit = {},
+) = AlkaaMultiplatformApp(
+    navigationAction = navigationAction,
+    modifier = Modifier.imePadding(),
+    onThemeUpdate = onThemeUpdate,
+)

--- a/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
+++ b/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
@@ -7,19 +7,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.escodro.designsystem.AlkaaTheme
+import com.escodro.navigation.NavigationAction
 import com.escodro.shared.model.AppThemeOptions
 import com.escodro.shared.navigation.AlkaaNavGraph
 import org.koin.compose.koinInject
 
 @Composable
 fun AlkaaMultiplatformApp(
+    navigationAction: NavigationAction = NavigationAction.Home,
     modifier: Modifier = Modifier,
     onThemeUpdate: (isDarkTheme: Boolean) -> Unit = {},
 ) {
     val isDarkTheme = rememberIsDarkTheme()
     onThemeUpdate(isDarkTheme)
     AlkaaTheme(isDarkTheme = isDarkTheme) {
-        AlkaaNavGraph(modifier)
+        AlkaaNavGraph(navigationAction = navigationAction, modifier = modifier)
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/escodro/shared/navigation/AlkaaNavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/escodro/shared/navigation/AlkaaNavGraph.kt
@@ -8,11 +8,14 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import cafe.adriel.voyager.core.registry.ScreenRegistry
+import cafe.adriel.voyager.navigator.CurrentScreen
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.bottomSheet.BottomSheetNavigator
 import cafe.adriel.voyager.navigator.bottomSheet.LocalBottomSheetNavigator
 import com.escodro.category.navigation.categoryScreenModule
 import com.escodro.home.navigation.HomeScreen
+import com.escodro.navigation.AlkaaDestinations
+import com.escodro.navigation.NavigationAction
 import com.escodro.preference.navigation.preferenceScreenModule
 import com.escodro.task.navigation.taskScreenModule
 import kotlinx.coroutines.flow.map
@@ -22,7 +25,7 @@ import kotlinx.coroutines.flow.map
  */
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun AlkaaNavGraph(modifier: Modifier = Modifier) {
+fun AlkaaNavGraph(navigationAction: NavigationAction, modifier: Modifier = Modifier) {
     ScreenRegistry {
         taskScreenModule()
         categoryScreenModule()
@@ -31,9 +34,25 @@ fun AlkaaNavGraph(modifier: Modifier = Modifier) {
 
     BottomSheetNavigator(modifier = modifier) {
         closeKeyboardOnBottomSheetDismiss()
-        Navigator(HomeScreen())
+        Navigator(screen = HomeScreen()) { navigator ->
+            CurrentScreen()
+            processNavigationAction(navigator = navigator, action = navigationAction)
+        }
     }
 }
+
+@Composable
+private fun processNavigationAction(navigator: Navigator, action: NavigationAction) =
+    when (action) {
+        is NavigationAction.Home -> {
+            /* Do nothing - Home is always the first screen in Alkaa */
+        }
+
+        is NavigationAction.TaskDetail -> {
+            val screen = ScreenRegistry.get(AlkaaDestinations.Task.TaskDetail(action.taskId))
+            navigator.push(screen)
+        }
+    }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable


### PR DESCRIPTION
Voyager does not have support for deep links or navigation from outside of the app at this moment. Because of that, a very simple structure was created to allow navigation through notifications and widgets using deep links. For now, it only applies to the Android platform.

The idea is to have a single deep link redirecting to the MainActivity and send a single extra, which is a sealed interface representing the destination and the parameters needed. The activity gets this information from the Intent and passes it to the navigation graph. After that, all the execution is multiplatform.

The navigation graph consumes the action and sends it to the appropriate screen (for now, only Task Details). If no information is provided, it stays on the home screen and no extra steps are taken.

For a more complex deep link interaction, we could send a Uri-like structure to be handled instead. But since Alkaa does not have any external deep link provider and we create all the intents internally, this is simpler and we don't need to worry about type safety.