### PR TITLE
⬆️ Upgrade AGP to 8.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Project
 version_code = "30000"
 version_name = "3.0.0"
-android_gradle_plugin = "8.2.1"
+android_gradle_plugin = "8.3.2"
 kotlin = "1.9.20"
 android_sdk_compile = "34"
 android_sdk_target = "33"

--- a/plugins/src/main/java/extension/CommonExtension.kt
+++ b/plugins/src/main/java/extension/CommonExtension.kt
@@ -4,7 +4,7 @@ import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.artifacts.VersionCatalog
 
-fun CommonExtension<*, *, *, *, *>.androidConfig(libs: VersionCatalog) {
+fun CommonExtension<*, *, *, *, *, *>.androidConfig(libs: VersionCatalog) {
 
     defaultConfig {
         compileSdk = Integer.parseInt(libs.sdkCompile)
@@ -17,7 +17,7 @@ fun CommonExtension<*, *, *, *, *>.androidConfig(libs: VersionCatalog) {
     }
 }
 
-fun CommonExtension<*, *, *, *, *>.composeConfig(libs: VersionCatalog) {
+fun CommonExtension<*, *, *, *, *, *>.composeConfig(libs: VersionCatalog) {
     buildFeatures {
         compose = true
     }


### PR DESCRIPTION
Update the AGP to the latest version and update the `CommonExtension` extension function adding the new wildcard for the new param in AGP 8.3.x.

Closes #635 