### PR TITLE
🔧 Update Info.plist to be in compliance with Apple request

### DIFF
--- a/ios-app/alkaa/Info.plist
+++ b/ios-app/alkaa/Info.plist
@@ -13,5 +13,7 @@
 	<string>Permission used by third-party libraries</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Permission used by third-party libraries</string>
+	<key>SPrivacyAccessedAPICategoryFileTimestamp</key>
+	<string>Timestamp used to set the creation and updated date in the tasks</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adding information on why SPrivacyAccessedAPICategoryFileTimestamp is used by our app.