### PR TITLE
🐞 Fix bug where the notification does not have the updated title in iOS

### DIFF
--- a/domain/src/commonMain/kotlin/com/escodro/domain/di/DomainModule.kt
+++ b/domain/src/commonMain/kotlin/com/escodro/domain/di/DomainModule.kt
@@ -76,6 +76,7 @@ val domainModule = module {
         UpdateTaskTitleImpl(
             loadTask = get(),
             updateTask = get(),
+            alarmInteractor = get(),
             glanceInteractor = getOrNull(),
         )
     }

--- a/domain/src/commonMain/kotlin/com/escodro/domain/interactor/AlarmInteractor.kt
+++ b/domain/src/commonMain/kotlin/com/escodro/domain/interactor/AlarmInteractor.kt
@@ -21,4 +21,11 @@ interface AlarmInteractor {
      * @param task the task alarm to be cancelled
      */
     fun cancel(task: Task)
+
+    /**
+     * Updates an existing alarm.
+     *
+     * @param task the task to be updated
+     */
+    fun update(task: Task)
 }

--- a/domain/src/commonMain/kotlin/com/escodro/domain/usecase/task/implementation/UpdateTaskTitleImpl.kt
+++ b/domain/src/commonMain/kotlin/com/escodro/domain/usecase/task/implementation/UpdateTaskTitleImpl.kt
@@ -1,5 +1,6 @@
 package com.escodro.domain.usecase.task.implementation
 
+import com.escodro.domain.interactor.AlarmInteractor
 import com.escodro.domain.interactor.GlanceInteractor
 import com.escodro.domain.usecase.task.LoadTask
 import com.escodro.domain.usecase.task.UpdateTask
@@ -8,6 +9,7 @@ import com.escodro.domain.usecase.task.UpdateTaskTitle
 internal class UpdateTaskTitleImpl(
     private val loadTask: LoadTask,
     private val updateTask: UpdateTask,
+    private val alarmInteractor: AlarmInteractor,
     private val glanceInteractor: GlanceInteractor?,
 ) : UpdateTaskTitle {
 
@@ -16,5 +18,10 @@ internal class UpdateTaskTitleImpl(
         val updatedTask = task.copy(title = title)
         updateTask(updatedTask)
         glanceInteractor?.onTaskListUpdated()
+
+        // Each platform deals with notifications in a different way - iOS gets the Task info AOT
+        if (task.dueDate != null) {
+            alarmInteractor.update(updatedTask)
+        }
     }
 }

--- a/domain/src/commonTest/kotlin/com/escodro/domain/usecase/fake/AlarmInteractorFake.kt
+++ b/domain/src/commonTest/kotlin/com/escodro/domain/usecase/fake/AlarmInteractorFake.kt
@@ -7,12 +7,18 @@ internal class AlarmInteractorFake : AlarmInteractor {
 
     private val alarmMap: MutableMap<Long, Long> = mutableMapOf()
 
+    var updatedTask: Task? = null
+
     override fun schedule(task: Task, timeInMillis: Long) {
         alarmMap[task.id] = timeInMillis
     }
 
     override fun cancel(task: Task) {
         alarmMap.remove(task.id)
+    }
+
+    override fun update(task: Task) {
+        updatedTask = task
     }
 
     fun isAlarmScheduled(alarmId: Long): Boolean =
@@ -23,5 +29,6 @@ internal class AlarmInteractorFake : AlarmInteractor {
 
     fun clear() {
         alarmMap.clear()
+        updatedTask = null
     }
 }

--- a/features/alarm/src/androidMain/kotlin/com/escodro/alarm/notification/AndroidNotificationScheduler.kt
+++ b/features/alarm/src/androidMain/kotlin/com/escodro/alarm/notification/AndroidNotificationScheduler.kt
@@ -45,4 +45,9 @@ internal class AndroidNotificationScheduler(private val context: Context) : Noti
         logcat { "Canceling notification with id '${task.title}'" }
         context.cancelAlarm(pendingIntent)
     }
+
+    override fun updateTaskNotification(task: Task) {
+        // In Android, the notification will trigger a Broadcast Receiver which will always get the
+        // most recent Task data from the database.
+    }
 }

--- a/features/alarm/src/commonMain/kotlin/com/escodro/alarm/interactor/AlarmInteractorImpl.kt
+++ b/features/alarm/src/commonMain/kotlin/com/escodro/alarm/interactor/AlarmInteractorImpl.kt
@@ -24,4 +24,10 @@ internal class AlarmInteractorImpl(
         val alarmTask = mapper.fromDomain(task)
         notificationScheduler.cancelTaskNotification(alarmTask)
     }
+
+    override fun update(task: Task) {
+        logger.debug { "update - alarmId = $task" }
+        val alarmTask = mapper.fromDomain(task)
+        notificationScheduler.updateTaskNotification(alarmTask)
+    }
 }

--- a/features/alarm/src/commonMain/kotlin/com/escodro/alarm/notification/NotificationScheduler.kt
+++ b/features/alarm/src/commonMain/kotlin/com/escodro/alarm/notification/NotificationScheduler.kt
@@ -21,4 +21,9 @@ internal interface NotificationScheduler {
      * @param task the task id to be canceled
      */
     fun cancelTaskNotification(task: Task)
+
+    /**
+     * Updates the notification with the given task information.
+     */
+    fun updateTaskNotification(task: Task)
 }

--- a/features/alarm/src/iosMain/kotlin/com/escodro/alarm/notification/IosNotificationScheduler.kt
+++ b/features/alarm/src/iosMain/kotlin/com/escodro/alarm/notification/IosNotificationScheduler.kt
@@ -1,6 +1,8 @@
 package com.escodro.alarm.notification
 
 import com.escodro.alarm.model.Task
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import platform.Foundation.NSCalendar
 import platform.Foundation.NSCalendarUnitDay
 import platform.Foundation.NSCalendarUnitHour
@@ -52,5 +54,14 @@ internal class IosNotificationScheduler : NotificationScheduler {
         NSLog("Canceling notification with id '${task.title}'")
         val notificationCenter = UNUserNotificationCenter.currentNotificationCenter()
         notificationCenter.removePendingNotificationRequestsWithIdentifiers(listOf(task.id.toString()))
+    }
+
+    override fun updateTaskNotification(task: Task) {
+        NSLog("Updating notification with id '${task.title}'")
+        val time = task.dueDate?.toInstant(
+            TimeZone.currentSystemDefault(),
+        )?.toEpochMilliseconds() ?: return
+
+        scheduleTaskNotification(task, time)
     }
 }


### PR DESCRIPTION
In iOS, the notification is scheduled with the task data when it is created. This means that if the title changes over time, the notification would show the outdated title when the notification is launched.

In this proposed fix, the notification is updated when the title changes, providing the latest info to the interactor.