### PR TITLE
✨ Add Alarm Selection in the Add Task Bottom Sheet

### DIFF
--- a/features/task/src/commonMain/kotlin/com/escodro/task/di/TaskModule.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/di/TaskModule.kt
@@ -50,6 +50,7 @@ val taskModule = module {
     viewModelDefinition {
         AddTaskViewModel(
             addTaskUseCase = get(),
+            alarmIntervalMapper = get(),
             applicationScope = get(),
         )
     }

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/AddTaskViewModel.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/AddTaskViewModel.kt
@@ -3,19 +3,34 @@ package com.escodro.task.presentation.add
 import com.escodro.coroutines.AppCoroutineScope
 import com.escodro.domain.model.Task
 import com.escodro.domain.usecase.task.AddTask
+import com.escodro.task.mapper.AlarmIntervalMapper
+import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.detail.main.CategoryId
 import dev.icerock.moko.mvvm.viewmodel.ViewModel
+import kotlinx.datetime.LocalDateTime
 
 internal class AddTaskViewModel(
     private val addTaskUseCase: AddTask,
+    private val alarmIntervalMapper: AlarmIntervalMapper,
     private val applicationScope: AppCoroutineScope,
 ) : ViewModel() {
 
-    fun addTask(title: String, categoryId: CategoryId?) {
+    fun addTask(
+        title: String,
+        categoryId: CategoryId?,
+        dueDate: LocalDateTime?,
+        alarmInterval: AlarmInterval = AlarmInterval.NEVER,
+    ) {
         if (title.isBlank()) return
 
+        val interval = alarmIntervalMapper.toDomain(alarmInterval)
         applicationScope.launch {
-            val task = Task(title = title, categoryId = categoryId?.value)
+            val task = Task(
+                title = title,
+                dueDate = dueDate,
+                categoryId = categoryId?.value,
+                alarmInterval = interval,
+            )
             addTaskUseCase.invoke(task)
         }
     }

--- a/features/task/src/test/java/com/escodro/task/presentation/fake/AddTaskFake.kt
+++ b/features/task/src/test/java/com/escodro/task/presentation/fake/AddTaskFake.kt
@@ -5,15 +5,13 @@ import com.escodro.domain.usecase.task.AddTask
 
 internal class AddTaskFake : AddTask {
 
-    private val updatedList: MutableList<Task> = mutableListOf()
+    var createdTask: Task? = null
 
     override suspend fun invoke(task: Task) {
-        updatedList.add(task)
+        createdTask = task
     }
 
-    fun clear() =
-        updatedList.clear()
-
-    fun wasTaskCreated(title: String): Boolean =
-        updatedList.any { it.title == title }
+    fun clear() {
+        createdTask = null
+    }
 }


### PR DESCRIPTION
This is a quality of life feature to quickly add alarms while the task is being created. This creates a better UX and allow users to use Alkaa as a quick reminder without going to an additional screen.