### PR TITLE
🥡 Small fix for Bottom Sheet

### DIFF
--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/TaskBottomSheet.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/TaskBottomSheet.kt
@@ -1,11 +1,13 @@
 package com.escodro.task.presentation.add
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -44,6 +46,7 @@ internal fun AddTaskBottomSheet(
         modifier = Modifier
             .fillMaxWidth()
             .fillMaxWidth(0.5f)
+            .background(MaterialTheme.colorScheme.surface)
             .padding(16.dp),
         verticalArrangement = Arrangement.SpaceAround,
     ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project
-version_code = "30003"
-version_name = "3.0.3"
+version_code = "30004"
+version_name = "3.0.4"
 android_gradle_plugin = "8.3.2"
 kotlin = "1.9.23"
 android_sdk_compile = "34"

--- a/ios-app/alkaa.xcodeproj/project.pbxproj
+++ b/ios-app/alkaa.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30003;
+				CURRENT_PROJECT_VERSION = 30004;
 				DEVELOPMENT_ASSET_PATHS = "\"alkaa/Preview Content\"";
 				DEVELOPMENT_TEAM = 5Z3927U4ZC;
 				ENABLE_PREVIEWS = YES;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.3;
+				MARKETING_VERSION = 3.0.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -377,7 +377,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30003;
+				CURRENT_PROJECT_VERSION = 30004;
 				DEVELOPMENT_ASSET_PATHS = "\"alkaa/Preview Content\"";
 				DEVELOPMENT_TEAM = 5Z3927U4ZC;
 				ENABLE_PREVIEWS = YES;
@@ -396,7 +396,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.3;
+				MARKETING_VERSION = 3.0.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",


### PR DESCRIPTION
A recent change to add the alarm option in the Bottom Sheet broke the background color. In removed the manual background color relying on that the `MaterialTheme` would work but didn't test it properly.