### PR TITLE
📐 Migrate Compose Rules to the new project 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           ALKAA_STORE_PATH: ${{ vars.ALKAA_STORE_PATH }}
 
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/config/filters/detekt.yml
+++ b/config/filters/detekt.yml
@@ -32,4 +32,3 @@ naming:
     excludes: [ '**/test/**','**/androidTest/**','**/android-test/**' ]
   FunctionNaming:
     ignoreAnnotated: [ 'Composable' ]
-

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/list/TaskList.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/list/TaskList.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -232,7 +233,7 @@ private fun TaskListError() {
  */
 @Composable
 private fun rememberRefreshKey(): Int {
-    var refreshKey by remember { mutableStateOf(0) }
+    var refreshKey by remember { mutableIntStateOf(0) }
     LaunchedEffect(Unit) {
         while (true) {
             delay(ComposableRefreshTime)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ test_manifest = "1.6.7"
 # Quality
 ktlint = "1.2.1"
 detekt = "1.23.6"
-composerules = "0.0.26"
+composerules = "0.4.1"
 
 # License
 aboutlibraries = "11.1.4"
@@ -147,7 +147,8 @@ test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref =
 # Quality
 ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-composerules = { module = "com.twitter.compose.rules:detekt", version.ref = "composerules" }
+composerules-detekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "composerules" }
+composerules-ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "composerules" }
 
 # License
 aboutlibraries_plugin = { module = "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin", version.ref = "aboutlibraries" }

--- a/libraries/splitInstall/src/main/java/com/escodro/splitinstall/SplitInstall.kt
+++ b/libraries/splitInstall/src/main/java/com/escodro/splitinstall/SplitInstall.kt
@@ -123,7 +123,7 @@ private fun DownloadFeature(
     setState: (SplitInstallState) -> Unit,
 ) {
     var isDialogOpen by rememberSaveable { mutableStateOf(true) }
-    DisposableEffect(featureName) {
+    DisposableEffect(featureName, setState, onDismiss) {
         val request = SplitInstallRequest.newBuilder()
             .addModule(featureName)
             .build()

--- a/plugins/src/main/java/extension/VersionCatalogLibraries.kt
+++ b/plugins/src/main/java/extension/VersionCatalogLibraries.kt
@@ -17,8 +17,10 @@ internal val VersionCatalog.kotlinxCollectionsImmutable: Provider<MinimalExterna
 internal val VersionCatalog.composeBom: Provider<MinimalExternalModuleDependency>
     get() = getLibrary("compose.bom")
 
-internal val VersionCatalog.composeRules: Provider<MinimalExternalModuleDependency>
-    get() = getLibrary("composerules")
+internal val VersionCatalog.composeRulesDetekt: Provider<MinimalExternalModuleDependency>
+    get() = getLibrary("composerules.detekt")
+
+internal val VersionCatalog.composeRulesKtlint: Provider<MinimalExternalModuleDependency>
+    get() = getLibrary("composerules.ktlint")
 
 private fun VersionCatalog.getLibrary(library: String) = findLibrary(library).get()
-

--- a/plugins/src/main/java/quality/detekt.gradle.kts
+++ b/plugins/src/main/java/quality/detekt.gradle.kts
@@ -1,6 +1,6 @@
 package quality
 
-import composeRules
+import composeRulesDetekt
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
@@ -10,7 +10,7 @@ val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().name
 apply<DetektPlugin>()
 
 dependencies {
-    "detektPlugins"(libs.composeRules)
+    "detektPlugins"(libs.composeRulesDetekt)
 }
 
 configure<DetektExtension> {

--- a/plugins/src/main/java/quality/ktlint.gradle.kts
+++ b/plugins/src/main/java/quality/ktlint.gradle.kts
@@ -1,5 +1,6 @@
 package quality
 
+import composeRulesKtlint
 import ktlint
 
 val ktlint: Configuration by configurations.creating
@@ -7,6 +8,7 @@ val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().name
 
 dependencies {
     ktlint(libs.ktlint)
+    ktlint.dependencies.add(libs.composeRulesKtlint.get())
 }
 
 tasks {

--- a/shared/src/androidMain/kotlin/com/escodro/shared/Main.android.kt
+++ b/shared/src/androidMain/kotlin/com/escodro/shared/Main.android.kt
@@ -9,14 +9,16 @@ import com.escodro.navigation.NavigationAction
  * Main view of the application.
  *
  * @param navigationAction the navigation action to be consumed when the app is open
+ * @param modifier the modifier to be applied to the view
  * @param onThemeUpdate the callback to be called when the theme is updated
  */
 @Composable
 fun MainView(
     navigationAction: NavigationAction,
+    modifier: Modifier = Modifier,
     onThemeUpdate: (isDarkTheme: Boolean) -> Unit = {},
 ) = AlkaaMultiplatformApp(
+    modifier = modifier.imePadding(),
     navigationAction = navigationAction,
-    modifier = Modifier.imePadding(),
     onThemeUpdate = onThemeUpdate,
 )

--- a/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
+++ b/shared/src/commonMain/kotlin/com/escodro/shared/AlkaaMultiplatformApp.kt
@@ -19,8 +19,8 @@ import org.koin.compose.koinInject
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun AlkaaMultiplatformApp(
-    navigationAction: NavigationAction = NavigationAction.Home,
     modifier: Modifier = Modifier,
+    navigationAction: NavigationAction = NavigationAction.Home,
     appState: AppState = rememberAlkaaAppState(windowSizeClass = calculateWindowSizeClass()),
     onThemeUpdate: (isDarkTheme: Boolean) -> Unit = {},
 ) {

--- a/shared/src/commonMain/kotlin/com/escodro/shared/navigation/AlkaaNavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/escodro/shared/navigation/AlkaaNavGraph.kt
@@ -37,7 +37,7 @@ fun AlkaaNavGraph(
     }
 
     BottomSheetNavigator(modifier = modifier) {
-        closeKeyboardOnBottomSheetDismiss()
+        CloseKeyboardOnBottomSheetDismiss()
         Navigator(screen = HomeScreen(appState = appState)) { navigator ->
             CurrentScreen()
             processNavigationAction(navigator = navigator, action = navigationAction)
@@ -59,7 +59,7 @@ private fun processNavigationAction(navigator: Navigator, action: NavigationActi
     }
 
 @Composable
-private fun closeKeyboardOnBottomSheetDismiss() {
+private fun CloseKeyboardOnBottomSheetDismiss() {
     val keyboardController = LocalSoftwareKeyboardController.current
     val bottomSheetNavigator = LocalBottomSheetNavigator.current
     LaunchedEffect(Unit) {


### PR DESCRIPTION
Ever since Twitter killed the Android Team, the ComposeRules project was deprecated and amazing devs from the community forked and support it. This change moves to the project and fixes the new lint rules