### PR TITLE
Add initial value to `DateTimePicker` and load existing value 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,12 +13,25 @@ plugins {
 android {
     defaultConfig {
         applicationId = "com.escodro.alkaa"
-        versionCode = Integer.parseInt(libs.versions.version.code.get())
-        versionName = libs.versions.version.name.get()
+        versionCode = Integer.parseInt(
+            libs.versions.version.code
+                .get(),
+        )
+        versionName = libs.versions.version.name
+            .get()
 
-        compileSdk = Integer.parseInt(libs.versions.android.sdk.compile.get())
-        minSdk = Integer.parseInt(libs.versions.android.sdk.min.get())
-        targetSdk = Integer.parseInt(libs.versions.android.sdk.target.get())
+        compileSdk = Integer.parseInt(
+            libs.versions.android.sdk.compile
+                .get(),
+        )
+        minSdk = Integer.parseInt(
+            libs.versions.android.sdk.min
+                .get(),
+        )
+        targetSdk = Integer.parseInt(
+            libs.versions.android.sdk.target
+                .get(),
+        )
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         setProperty("archivesBaseName", "${parent?.name}-$versionName")
@@ -48,8 +61,11 @@ android {
         htmlReport = true
         checkDependencies = true
 
-        lintConfig = file("${rootDir}/config/filters/lint.xml")
-        htmlOutput = layout.buildDirectory.file("reports/lint.html").get().asFile
+        lintConfig = file("$rootDir/config/filters/lint.xml")
+        htmlOutput = layout.buildDirectory
+            .file("reports/lint.html")
+            .get()
+            .asFile
 
         project.tasks.check.dependsOn("lint")
     }
@@ -64,7 +80,6 @@ android {
     buildFeatures {
         compose = true
     }
-
 
     packaging {
         resources.excludes.apply {
@@ -83,13 +98,13 @@ android {
                         device = "Pixel 2"
                         apiLevel = 27
                         systemImageSource = "aosp"
-                    }
+                    },
                 )
             }
             groups {
                 create("alkaaDevices").apply {
                     targetDevices.addAll(
-                        listOf(devices.getByName("pixel2api27"))
+                        listOf(devices.getByName("pixel2api27")),
                     )
                 }
                 unitTests.isReturnDefaultValues = true

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -45,6 +46,7 @@ internal fun AlarmSelection(
 
     // Date Time Picker dialog
     DateTimerPicker(
+        initialDateTime=  alarmSelectionState.date,
         isDialogOpen = alarmSelectionState.showDateTimePickerDialog,
         onCloseDialog = { alarmSelectionState.showDateTimePickerDialog = false },
         onDateChange = { dateTime ->

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/AlarmSelection.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -46,7 +45,7 @@ internal fun AlarmSelection(
 
     // Date Time Picker dialog
     DateTimerPicker(
-        initialDateTime=  alarmSelectionState.date,
+        initialDateTime = alarmSelectionState.date,
         isDialogOpen = alarmSelectionState.showDateTimePickerDialog,
         onCloseDialog = { alarmSelectionState.showDateTimePickerDialog = false },
         onDateChange = { dateTime ->

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/DateTimePicker.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/DateTimePicker.kt
@@ -20,7 +20,6 @@ import com.escodro.resources.dialog_picker_next
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/DateTimePicker.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/detail/alarm/DateTimePicker.kt
@@ -20,15 +20,18 @@ import com.escodro.resources.dialog_picker_next
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 
 /**
  * Composable to show a date and time picker.
  *
+ * @param initialDateTime a pre-existing value set by user
  * @param isDialogOpen if the dialog should be open
  * @param onCloseDialog callback called when the dialog is closed
  * @param onDateChange callback called when the date is changed
@@ -36,24 +39,26 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DateTimerPicker(
+    initialDateTime: LocalDateTime?,
     isDialogOpen: Boolean,
     onCloseDialog: () -> Unit,
     onDateChange: (LocalDateTime) -> Unit,
 ) {
     val now = Clock.System.now()
-    val displayTime = now
+    val displayTime = initialDateTime ?: now
         .plus(
             value = 1,
             unit = DateTimeUnit.HOUR,
             timeZone = TimeZone.currentSystemDefault(),
         ).toLocalDateTime(TimeZone.currentSystemDefault())
 
+    val initialSelectedDate = initialDateTime?.toInstant(TimeZone.currentSystemDefault()) ?: now
     val datePickerState = rememberDatePickerState(
-        initialSelectedDateMillis = now.toEpochMilliseconds(),
+        initialSelectedDateMillis = initialSelectedDate.toEpochMilliseconds(),
     )
     val timePickerState = rememberTimePickerState(
         initialHour = displayTime.hour,
-        initialMinute = 0,
+        initialMinute = displayTime.minute,
     )
     var dialogState by remember(isDialogOpen) { mutableStateOf(DateTimePickerState.DATE) }
 

--- a/plugins/src/main/java/com.escodro.kotlin-parcelable.gradle.kts
+++ b/plugins/src/main/java/com.escodro.kotlin-parcelable.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
         compilerOptions {
             freeCompilerArgs.addAll(
                 "-P",
-                "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.escodro.parcelable.CommonParcelize"
+                "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.escodro.parcelable.CommonParcelize",
             )
         }
     }

--- a/plugins/src/main/java/com.escodro.kotlin-quality.gradle.kts
+++ b/plugins/src/main/java/com.escodro.kotlin-quality.gradle.kts
@@ -7,7 +7,7 @@ tasks.getByName("check") {
     setDependsOn(
         listOf(
             tasks.getByName("ktlint"),
-            tasks.getByName("detekt")
-        )
+            tasks.getByName("detekt"),
+        ),
     )
 }

--- a/plugins/src/main/java/extension/CommonExtension.kt
+++ b/plugins/src/main/java/extension/CommonExtension.kt
@@ -5,7 +5,6 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.artifacts.VersionCatalog
 
 fun CommonExtension<*, *, *, *, *, *>.androidConfig(libs: VersionCatalog) {
-
     defaultConfig {
         compileSdk = Integer.parseInt(libs.sdkCompile)
         minSdk = Integer.parseInt(libs.sdkMin)

--- a/plugins/src/main/java/extension/KmpExtensions.kt
+++ b/plugins/src/main/java/extension/KmpExtensions.kt
@@ -2,7 +2,6 @@ package extension
 
 import org.gradle.kotlin.dsl.get
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 
 /**
  * Sets the base name for the Objective-C framework.
@@ -13,7 +12,7 @@ fun KotlinMultiplatformExtension.setFrameworkBaseName(name: String) {
     listOf(
         iosX64(),
         iosArm64(),
-        iosSimulatorArm64()
+        iosSimulatorArm64(),
     ).forEach {
         it.binaries.framework {
             baseName = name

--- a/plugins/src/main/java/quality/ktlint.gradle.kts
+++ b/plugins/src/main/java/quality/ktlint.gradle.kts
@@ -16,10 +16,14 @@ tasks {
         description = "Check Kotlin code style."
         classpath = ktlint
         mainClass.set("com.pinterest.ktlint.Main")
-        val buildDir = layout.buildDirectory.get().asFile.path
+        val buildDir = layout.buildDirectory
+            .get()
+            .asFile.path
         args(
-            "src/**/*.kt", "--reporter=plain", "--reporter=checkstyle," +
-                "output=${buildDir}/reports/ktlint.xml"
+            "src/**/*.kt",
+            "--reporter=plain",
+            "--reporter=checkstyle," +
+                "output=$buildDir/reports/ktlint.xml",
         )
     }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
     listOf(
         iosX64(),
         iosArm64(),
-        iosSimulatorArm64()
+        iosSimulatorArm64(),
     ).forEach {
         it.binaries.framework {
             baseName = "shared"


### PR DESCRIPTION
This commit fixes #769
* `DateTimePicker` now has a field for its initial value
* The alarm will load the existing value if it exists