### PR TITLE
☢️ Remove AtomicFU

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,12 +13,10 @@ buildscript {
         classpath(libs.android.gradle.plugin)
         classpath(libs.kotlin.gradle.plugin)
         classpath(libs.aboutlibraries.plugin)
-        classpath(libs.kotlin.atomicfu)
     }
 }
 
 allprojects {
-    apply(plugin = "kotlinx-atomicfu")
     repositories {
         google()
         mavenCentral()

--- a/data/datastore/src/commonMain/kotlin/com/escodro/datastore/DataStore.kt
+++ b/data/datastore/src/commonMain/kotlin/com/escodro/datastore/DataStore.kt
@@ -3,12 +3,14 @@ package com.escodro.datastore
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import kotlinx.atomicfu.locks.SynchronizedObject
-import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.SynchronizedObject
+import kotlinx.coroutines.internal.synchronized
 import okio.Path.Companion.toPath
 
 private lateinit var dataStore: DataStore<Preferences>
 
+@OptIn(InternalCoroutinesApi::class)
 private val lock = SynchronizedObject()
 
 /**
@@ -18,6 +20,7 @@ private val lock = SynchronizedObject()
  *
  * @return the [DataStore] instance
  */
+@OptIn(InternalCoroutinesApi::class)
 fun getDataStore(producePath: () -> String): DataStore<Preferences> =
     synchronized(lock) {
         if (::dataStore.isInitialized) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,3 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
-
-# Ignore AtomicFU warnings - will be fixed in Kotlin 2.0
-# (https://github.com/Kotlin/kotlinx-atomicfu/issues/376
-kotlin.native.ignoreIncorrectDependencies=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,9 +54,6 @@ sqldelight = "2.0.2"
 moko = "0.16.1"
 moko_permissions = "0.18.1"
 
-# AtomicFU
-atomicfu = "0.24.0"
-
 # Voyager
 voyager = "1.1.0-beta02"
 
@@ -78,7 +75,6 @@ aboutlibraries = "11.2.3"
 # Project
 android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref = "android_gradle_plugin" }
 kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin_atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
 
 # General dependencies
 logging = { module = "io.github.microutils:kotlin-logging", version.ref = "logging" }


### PR DESCRIPTION
Removing the library since it generates some conflicts with other libraries, and it's only used in Alkaa to make DataStore.kt a singleton.
For now, the code was updated to use the same sync functions from the stdlib.