### PR TITLE
🦟 Fix iOS crash related to CADisableMinimumFrameDurationOnPhone

### DIFF
--- a/ios-app/alkaa/Info.plist
+++ b/ios-app/alkaa/Info.plist
@@ -17,5 +17,6 @@
 	<string>Permission used by third-party libraries</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Permission used by third-party libraries</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
 </dict>
 </plist>


### PR DESCRIPTION
The iOS app was crashing after a few seconds being open because of the missing Info.plist property.