### PR TITLE
🪪 Disable License Badges for AboutLibraries

### DIFF
--- a/features/preference/src/commonMain/kotlin/com/escodro/preference/presentation/OpenSource.kt
+++ b/features/preference/src/commonMain/kotlin/com/escodro/preference/presentation/OpenSource.kt
@@ -40,6 +40,7 @@ private fun OpenSourceContent(modifier: Modifier = Modifier) {
 
     LibrariesContainer(
         aboutLibsJson = licenses.decodeToString(),
+        showLicenseBadges = false,
         modifier = modifier.fillMaxSize(),
         colors = LibraryDefaults.libraryColors(
             backgroundColor = MaterialTheme.colorScheme.background,


### PR DESCRIPTION
Occasionally, the AboutLibraries breaks the app during Compose updates. This happens due to a `No static method FlowRow` error for the License Badges. To avoid this constant issue, a simple workaround is to remove the component from the list.

Source: https://github.com/mikepenz/AboutLibraries/issues/1033