### PR TITLE
Fix: improve bottom sheet animation

### DIFF
--- a/features/category/src/commonMain/kotlin/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
+++ b/features/category/src/commonMain/kotlin/com/escodro/category/presentation/bottomsheet/CategoryBottomSheet.kt
@@ -159,9 +159,6 @@ private fun CategoryBottomSheet(
             onHideBottomSheet()
         },
     ) {
-        LaunchedEffect(Unit) {
-            sheetState.show()
-        }
         CategoryBottomSheetContent(
             state = state,
             onCategoryRemove = onCategoryRemove,

--- a/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/TaskBottomSheet.kt
+++ b/features/task/src/commonMain/kotlin/com/escodro/task/presentation/add/TaskBottomSheet.kt
@@ -62,9 +62,6 @@ internal fun AddTaskBottomSheet(
             onHideBottomSheet()
         },
     ) {
-        LaunchedEffect(Unit) {
-            sheetState.show()
-        }
         AddTaskBottomSheetContent(onHideBottomSheet = onHideBottomSheet)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,6 @@ include(":libraries:appstate")
 include(":libraries:parcelable")
 include(":libraries:permission")
 
-
 include(":domain")
 include(":shared")
 include(":resources")


### PR DESCRIPTION
I read the [official documentation](https://developer.android.com/develop/ui/compose/components/bottom-sheets?hl=en) and I noticed that the examples are not using `.show()`. My speculation is that the animation is called by default, and the original code duplicated the animation, leading to the behaviour shown in the demo.

Here is a demo of this PR:

https://github.com/user-attachments/assets/c659918e-ec35-48c8-b436-1c7882d5d124

Fixes #864.
