### PR TITLE
🧱 Add @CommonIgnoredOnParcel to HomeDestination members

### DIFF
--- a/features/navigation-api/src/commonMain/kotlin/com/escodro/navigationapi/destination/HomeDestination.kt
+++ b/features/navigation-api/src/commonMain/kotlin/com/escodro/navigationapi/destination/HomeDestination.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.escodro.navigationapi.marker.TopLevel
+import com.escodro.parcelable.CommonIgnoredOnParcel
 import com.escodro.parcelable.CommonParcelize
 import com.escodro.resources.Res
 import com.escodro.resources.home_title_categories
@@ -21,28 +22,44 @@ object HomeDestination {
     @Serializable
     @CommonParcelize
     data object TaskList : Destination, TopLevel {
+
+        @CommonIgnoredOnParcel
         override val title: StringResource = Res.string.home_title_tasks
+
+        @CommonIgnoredOnParcel
         override val icon: ImageVector = Icons.Outlined.Check
     }
 
     @Serializable
     @CommonParcelize
     data object Search : Destination, TopLevel {
+
+        @CommonIgnoredOnParcel
         override val title: StringResource = Res.string.home_title_search
+
+        @CommonIgnoredOnParcel
         override val icon: ImageVector = Icons.Outlined.Search
     }
 
     @Serializable
     @CommonParcelize
     data object CategoryList : Destination, TopLevel {
+
+        @CommonIgnoredOnParcel
         override val title: StringResource = Res.string.home_title_categories
+
+        @CommonIgnoredOnParcel
         override val icon: ImageVector = Icons.Outlined.Bookmark
     }
 
     @Serializable
     @CommonParcelize
     data object Preferences : Destination, TopLevel {
+
+        @CommonIgnoredOnParcel
         override val title: StringResource = Res.string.home_title_settings
+
+        @CommonIgnoredOnParcel
         override val icon: ImageVector = Icons.Outlined.MoreHoriz
     }
 }

--- a/libraries/parcelable/build.gradle.kts
+++ b/libraries/parcelable/build.gradle.kts
@@ -2,6 +2,7 @@ import extension.setFrameworkBaseName
 
 plugins {
     id("com.escodro.multiplatform")
+    id("kotlin-parcelize")
 }
 
 kotlin {

--- a/libraries/parcelable/src/commonMain/kotlin/com/escodro/parcelable/CommonParcelable.kt
+++ b/libraries/parcelable/src/commonMain/kotlin/com/escodro/parcelable/CommonParcelable.kt
@@ -3,6 +3,8 @@ package com.escodro.parcelable
 /**
  * Annotation to be used in the common code to enable the Parcelable generation in KMP.
  */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
 annotation class CommonParcelize
 
 /**
@@ -12,3 +14,10 @@ annotation class CommonParcelize
  * See: https://issuetracker.google.com/issues/315775835#comment16
  */
 expect interface CommonParcelable
+
+/**
+ * Annotation to be used in the common code to ignore a property from the Parcelable generation.
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+expect annotation class CommonIgnoredOnParcel()

--- a/libraries/parcelable/src/desktopMain/kotlin/com/escodro/parcelable/CommonParcelable.desktop.kt
+++ b/libraries/parcelable/src/desktopMain/kotlin/com/escodro/parcelable/CommonParcelable.desktop.kt
@@ -1,3 +1,5 @@
 package com.escodro.parcelable
 
 actual interface CommonParcelable
+
+actual annotation class CommonIgnoredOnParcel

--- a/libraries/parcelable/src/iosMain/kotlin/com/escodro/parcelable/CommonParcelable.ios.kt
+++ b/libraries/parcelable/src/iosMain/kotlin/com/escodro/parcelable/CommonParcelable.ios.kt
@@ -1,3 +1,5 @@
 package com.escodro.parcelable
 
 actual interface CommonParcelable
+
+actual annotation class CommonIgnoredOnParcel

--- a/libraries/parcelable/src/main/java/com/escodro/parcelable/CommonParcelable.android.kt
+++ b/libraries/parcelable/src/main/java/com/escodro/parcelable/CommonParcelable.android.kt
@@ -1,3 +1,5 @@
 package com.escodro.parcelable
 
 actual typealias CommonParcelable = android.os.Parcelable
+
+actual typealias CommonIgnoredOnParcel = kotlinx.parcelize.IgnoredOnParcel


### PR DESCRIPTION
The `title` and `icon` members of the `HomeDestination` data objects are now annotated with `@CommonIgnoredOnParcel`. This will suppress the build warning related to these properties.