### PR TITLE
🛠️ Update Android compile SDK version to 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ version_code = "30301"
 version_name = "3.3.1"
 android_gradle_plugin = "8.12.1"
 kotlin = "2.2.10"
-android_sdk_compile = "35"
+android_sdk_compile = "36"
 android_sdk_target = "35"
 android_sdk_min = "24"
 


### PR DESCRIPTION
Bumped the `android_sdk_compile` version from 35 to 36 in the Gradle configuration.