### PR TITLE
🧪 Remove runBlocking from tests by supporting suspend blocks

### DIFF
--- a/.claude/skills/write-e2e-tests/SKILL.md
+++ b/.claude/skills/write-e2e-tests/SKILL.md
@@ -34,7 +34,7 @@ No camelCase, no backtick names.
 | **`cleanTable()` in `@BeforeTest`** | Call on every DAO used to avoid state leakage between tests |
 | **DAO-based seeding** | Insert test data directly via DAOs — not via use cases |
 | **Content descriptions for navigation** | Navigate via content descriptions, not raw text |
-| **Resource strings** | `runBlocking { getString(Res.string.xyz) }` — never hardcode |
+| **Resource strings** | `getString(Res.string.xyz)` inside `uiTest` or `runComposeUiTest` — never hardcode |
 | **Fakes over mocks** | Use `declare<T> { FakeImpl() }` for external dependencies |
 | **`@AfterTest` always** | Always call `afterTest()` to stop Koin after each test |
 
@@ -45,7 +45,7 @@ No camelCase, no backtick names.
 | Calling `by inject()` before `beforeTest()` | Always call `beforeTest()` first |
 | Skipping `cleanTable()` | Call on every DAO to avoid state leakage |
 | Using `flakyUiTest` by default | Reserve for tests with known timing sensitivity |
-| Hardcoding UI strings | Use `runBlocking { getString(...) }` |
+| Hardcoding UI strings | Use `getString(...)` inside `uiTest` or `runComposeUiTest` |
 | Testing multiple flows in one test | One scenario per test |
 | Missing `@AfterTest` / `afterTest()` | Always stop Koin after each test |
 | Navigation via raw text | Navigate via content descriptions |

--- a/.claude/skills/write-e2e-tests/references/SETUP.md
+++ b/.claude/skills/write-e2e-tests/references/SETUP.md
@@ -95,11 +95,14 @@ Use `useUnmergedTree = true` when nodes are inside merged semantics.
 
 ## Resource Strings
 
-Never hardcode UI strings. Resolve them at test time:
+Never hardcode UI strings. Resolve them at test time inside `uiTest` or `runComposeUiTest` (as they are suspendable):
 
 ```kotlin
-val emptyMessage = runBlocking { getString(Res.string.tracker_header_empty) }
-onNodeWithText(text = emptyMessage).assertExists()
+@Test
+fun test_something() = uiTest {
+    val emptyMessage = getString(Res.string.tracker_header_empty)
+    onNodeWithText(text = emptyMessage).assertExists()
+}
 ```
 
 ## Fake Dependencies

--- a/.claude/skills/write-ui-tests/SKILL.md
+++ b/.claude/skills/write-ui-tests/SKILL.md
@@ -32,7 +32,7 @@ No camelCase, no backtick names.
 | Rule | Details |
 |------|---------|
 | **Always wrap** | Wrap composable in `AlkaaThemePreview` |
-| **Resource strings** | `runBlocking { getString(Res.string.xyz) }` — never hardcode |
+| **Resource strings** | `getString(Res.string.xyz)` inside `uiTest` or `runComposeUiTest` — never hardcode |
 | **One scenario per test** | Split different states into separate `@Test` functions |
 | **`useUnmergedTree = true`** | When nodes are inside merged semantics |
 | **`@IgnoreOnDesktop`** | For tests not applicable on desktop |
@@ -45,7 +45,7 @@ No camelCase, no backtick names.
 |---------|-----|
 | Testing a stateful composable directly | Extract a stateless Content composable and test that |
 | Using mocks for domain interfaces | Create a fake implementing the interface |
-| Hardcoding UI strings | Use `runBlocking { getString(...) }` |
+| Hardcoding UI strings | Use `getString(...)` inside `uiTest` or `runComposeUiTest` |
 | Testing multiple scenarios in one test | Split into separate `@Test` functions |
 | Missing `@AfterTest` cleanup | Add `tearDown()` calling `clean()` on every fake |
 | Forgetting `AlkaaThemePreview` wrapper | Always wrap composable |

--- a/.claude/skills/write-ui-tests/references/SETUP.md
+++ b/.claude/skills/write-ui-tests/references/SETUP.md
@@ -120,11 +120,20 @@ Use `useUnmergedTree = true` when nodes are nested inside merged semantics.
 
 ## Resource Strings
 
-Resolve Compose Multiplatform string resources at test time via `runBlocking`:
+Resolve Compose Multiplatform string resources at test time directly inside `uiTest` or `runComposeUiTest` (as they are suspendable):
 
 ```kotlin
-val header = runBlocking { getString(Res.string.task_list_header_error) }
-onNodeWithText(text = header).assertExists()
+@Test
+fun test_something() = uiTest {
+    val header = getString(Res.string.task_list_header_error)
+    onNodeWithText(text = header).assertExists()
+}
+
+@Test
+fun test_standalone() = runComposeUiTest {
+    val header = getString(Res.string.task_list_header_error)
+    onNodeWithText(text = header).assertExists()
+}
 ```
 
 Never hardcode UI strings in tests.
@@ -145,7 +154,7 @@ Use comments to separate the three blocks:
 
 ```kotlin
 @Test
-fun test_errorViewIsShown() = runComposeUiTest {
+fun test_errorViewIsShown() = uiTest {
     // Given an error state
     val state = TaskListViewState.Error(IllegalStateException())
 
@@ -153,7 +162,7 @@ fun test_errorViewIsShown() = runComposeUiTest {
     loadTaskList(state)
 
     // Then the error view is shown
-    val header = runBlocking { getString(Res.string.task_list_header_error) }
+    val header = getString(Res.string.task_list_header_error)
     onNodeWithText(text = header).assertExists()
 }
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ freeline_project_description.json
 
 # AI generated files
 /.output.txt
+*.DS_Store

--- a/features/search/src/commonTest/kotlin/com/escodro/search/presentation/instrumented/SearchSectionTest.kt
+++ b/features/search/src/commonTest/kotlin/com/escodro/search/presentation/instrumented/SearchSectionTest.kt
@@ -14,7 +14,6 @@ import com.escodro.search.presentation.SearchScaffold
 import com.escodro.search.presentation.SearchViewState
 import com.escodro.test.AlkaaTest
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import kotlin.test.Test
 
@@ -30,8 +29,8 @@ internal class SearchSectionTest : AlkaaTest() {
         loadTaskList(state)
 
         // Assert that the empty view is loaded
-        val header = runBlocking { getString(Res.string.search_header_empty) }
-        val contentDescription = runBlocking { getString(Res.string.search_cd_empty_list) }
+        val header = getString(Res.string.search_header_empty)
+        val contentDescription = getString(Res.string.search_cd_empty_list)
         onNodeWithText(text = header).assertExists()
         onNodeWithContentDescription(label = contentDescription).assertExists()
     }

--- a/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/AlarmPermissionFlowTest.kt
+++ b/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/AlarmPermissionFlowTest.kt
@@ -13,7 +13,6 @@ import com.escodro.task.presentation.detail.alarm.AlarmSelectionState
 import com.escodro.task.presentation.detail.alarm.interactor.OpenAlarmSchedulerImpl
 import com.escodro.task.presentation.fake.PermissionControllerFake
 import com.escodro.test.AlkaaTest
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -45,7 +44,7 @@ internal class AlarmPermissionFlowTest : AlkaaTest() {
             hasAlarmPermission = true,
         )
 
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         assertFalse(state.isNotificationDialogOpen)
@@ -62,7 +61,7 @@ internal class AlarmPermissionFlowTest : AlkaaTest() {
             hasAlarmPermission = true,
         )
 
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         assertTrue(state.isNotificationDialogOpen)
@@ -77,7 +76,7 @@ internal class AlarmPermissionFlowTest : AlkaaTest() {
             hasAlarmPermission = false,
         )
 
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         assertFalse(state.isNotificationDialogOpen)
@@ -94,7 +93,7 @@ internal class AlarmPermissionFlowTest : AlkaaTest() {
             hasAlarmPermission = false,
         )
 
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         assertTrue(state.isNotificationDialogOpen)

--- a/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/AlarmSelectionTest.kt
+++ b/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/AlarmSelectionTest.kt
@@ -22,7 +22,6 @@ import com.escodro.task.presentation.detail.alarm.interactor.OpenAlarmSchedulerI
 import com.escodro.task.presentation.fake.PermissionControllerFake
 import com.escodro.test.AlkaaTest
 import com.escodro.test.annotation.IgnoreOnDesktop
-import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.compose.resources.getString
 import org.koin.compose.KoinApplication
@@ -51,7 +50,7 @@ internal class AlarmSelectionTest : AlkaaTest() {
         loadAlarmSelection()
 
         // Click in the alarm item
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         // Since we are using a fake that doesn't actually open a picker, we can't easily set the date
@@ -63,18 +62,19 @@ internal class AlarmSelectionTest : AlkaaTest() {
     @Test
     fun test_addAndRemoveAlarm() = runComposeUiTest {
         // Load the alarm section component (with a preset date to test removal)
-        val localDateTime = LocalDateTime(year = 2021, month = 4, day = 15, hour = 17, minute = 0)
+        val localDateTime =
+            LocalDateTime(year = 2021, month = 4, day = 15, hour = 17, minute = 0)
         loadAlarmSelection(localDateTime, AlarmInterval.NEVER)
 
         // Click to remove the alarm
-        val removeAlarmCd = runBlocking { getString(Res.string.task_detail_cd_icon_remove_alarm) }
+        val removeAlarmCd = getString(Res.string.task_detail_cd_icon_remove_alarm)
         onNodeWithContentDescription(removeAlarmCd, useUnmergedTree = true).performClick()
 
         // Assert that the alarm item is not set again
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).assertIsDisplayed()
 
-        val repeatIconCd = runBlocking { getString(Res.string.task_detail_cd_icon_repeat_alarm) }
+        val repeatIconCd = getString(Res.string.task_detail_cd_icon_repeat_alarm)
         onNodeWithText(repeatIconCd).assertDoesNotExist()
     }
 
@@ -85,11 +85,10 @@ internal class AlarmSelectionTest : AlkaaTest() {
         loadAlarmSelection(localDateTime, AlarmInterval.NEVER)
 
         // Assert that when clicking in each option, it is shown as selected
-        val repeatIconCd = runBlocking { getString(Res.string.task_detail_cd_icon_repeat_alarm) }
-
+        val repeatIconCd = getString(Res.string.task_detail_cd_icon_repeat_alarm)
         AlarmInterval.entries.forEach { interval ->
             onNodeWithContentDescription(repeatIconCd, useUnmergedTree = true).performClick()
-            val intervalString = runBlocking { getString(interval.title) }
+            val intervalString = getString(interval.title)
             onAllNodesWithText(intervalString)[0].performClick()
             onAllNodesWithText(intervalString)[0].assertIsDisplayed()
         }
@@ -102,7 +101,7 @@ internal class AlarmSelectionTest : AlkaaTest() {
         val alarmInterval = AlarmInterval.MONTHLY
         loadAlarmSelection(localDateTime, alarmInterval)
 
-        val alarmString = runBlocking { getString(alarmInterval.title) }
+        val alarmString = getString(alarmInterval.title)
 
         // Assert that the date is shown in the view
         onNodeWithText(text = "15", substring = true).assertIsDisplayed()
@@ -119,11 +118,11 @@ internal class AlarmSelectionTest : AlkaaTest() {
         loadAlarmSelection(hasExactAlarmPermission = false)
 
         // Click in the alarm item
-        val noAlarmString = runBlocking { getString(Res.string.task_detail_alarm_no_alarm) }
+        val noAlarmString = getString(Res.string.task_detail_alarm_no_alarm)
         onNodeWithText(noAlarmString).performClick()
 
         // Assert that the alarm item is not set again
-        val dialogTitle = runBlocking { getString(Res.string.task_alarm_permission_dialog_title) }
+        val dialogTitle = getString(Res.string.task_alarm_permission_dialog_title)
         onNodeWithText(dialogTitle).assertIsDisplayed()
     }
 

--- a/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/CategorySelectionTest.kt
+++ b/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/CategorySelectionTest.kt
@@ -18,7 +18,6 @@ import com.escodro.test.AlkaaTest
 import com.escodro.test.annotation.IgnoreOnDesktop
 import com.escodro.test.extension.onChip
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import kotlin.test.Test
 
@@ -117,7 +116,7 @@ internal class CategorySelectionTest : AlkaaTest() {
         }
 
         // Then text informing there are no categories is shown
-        val emptyTextInfo = runBlocking { getString(Res.string.task_detail_category_empty_list) }
+        val emptyTextInfo = getString(Res.string.task_detail_category_empty_list)
         onNodeWithText(emptyTextInfo).assertExists()
     }
 

--- a/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/TaskDetailTest.kt
+++ b/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/TaskDetailTest.kt
@@ -20,7 +20,6 @@ import com.escodro.task.presentation.fake.OpenAlarmSchedulerFake
 import com.escodro.task.presentation.fake.PermissionControllerFake
 import com.escodro.test.AlkaaTest
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import org.koin.compose.KoinApplication
 import org.koin.core.context.stopKoin
@@ -51,8 +50,8 @@ internal class TaskDetailTest : AlkaaTest() {
         loadTaskDetail(state)
 
         // Assert that the error view is loaded
-        val header = runBlocking { getString(Res.string.task_detail_header_error) }
-        val contentDescription = runBlocking { getString(Res.string.task_detail_cd_error) }
+        val header = getString(Res.string.task_detail_header_error)
+        val contentDescription = getString(Res.string.task_detail_cd_error)
         onNodeWithText(text = header).assertExists()
         onNodeWithContentDescription(label = contentDescription).assertExists()
     }

--- a/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/TaskListTest.kt
+++ b/features/task/src/commonTest/kotlin/com/escodro/task/presentation/instrumented/TaskListTest.kt
@@ -22,7 +22,6 @@ import com.escodro.task.presentation.list.TaskListViewState
 import com.escodro.test.AlkaaTest
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import kotlin.test.Test
 
@@ -38,8 +37,8 @@ internal class TaskListTest : AlkaaTest() {
         loadTaskList(state)
 
         // Assert that the error view is loaded
-        val header = runBlocking { getString(Res.string.task_list_header_error) }
-        val contentDescription = runBlocking { getString(Res.string.task_list_cd_error) }
+        val header = getString(Res.string.task_list_header_error)
+        val contentDescription = getString(Res.string.task_list_cd_error)
         onNodeWithText(text = header).assertExists()
         onNodeWithContentDescription(label = contentDescription).assertExists()
     }
@@ -53,8 +52,8 @@ internal class TaskListTest : AlkaaTest() {
         loadTaskList(state)
 
         // Assert that the empty view is loaded
-        val header = runBlocking { getString(Res.string.task_list_header_empty) }
-        val contentDescription = runBlocking { getString(Res.string.task_list_cd_empty_list) }
+        val header = getString(Res.string.task_list_header_empty)
+        val contentDescription = getString(Res.string.task_list_cd_empty_list)
         onNodeWithText(text = header).assertExists()
         onNodeWithContentDescription(label = contentDescription).assertExists()
     }

--- a/shared/src/commonTest/kotlin/com/escodro/alkaa/HomeScreenTest.kt
+++ b/shared/src/commonTest/kotlin/com/escodro/alkaa/HomeScreenTest.kt
@@ -24,7 +24,6 @@ import com.escodro.local.dao.TaskDao
 import com.escodro.navigationapi.destination.HomeDestination
 import com.escodro.navigationapi.destination.TopLevelDestinations
 import com.escodro.test.AlkaaTest
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.compose.resources.getString
 import org.koin.test.KoinTest
@@ -54,7 +53,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
     @Test
     fun when_tab_changes_then_title_updates() = uiTest {
         TopLevelDestinations.forEach { section ->
-            val title = runBlocking { getString(section.title) }
+            val title = getString(section.title)
 
             // Click on each item and validate the title
             onNodeWithContentDescription(label = title, useUnmergedTree = true).performClick()
@@ -65,7 +64,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
     @Test
     fun when_tab_changes_and_back_pressed_then_title_updates() = uiTest {
         // Click on Settings tab
-        val settingsTitle = runBlocking { getString(HomeDestination.Preferences.title) }
+        val settingsTitle = getString(HomeDestination.Preferences.title)
         onNodeWithContentDescription(label = settingsTitle, useUnmergedTree = true).performClick()
         onNodeWithTag(HomeDestination.Preferences.title.toString()).assertIsSelected()
 
@@ -76,7 +75,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
         }
 
         // Click on Tasks tab
-        val tasksTitle = runBlocking { getString(HomeDestination.TaskList.title) }
+        val tasksTitle = getString(HomeDestination.TaskList.title)
         onNodeWithContentDescription(label = tasksTitle, useUnmergedTree = true).performClick()
         onNodeWithTag(HomeDestination.TaskList.title.toString()).assertIsSelected()
     }
@@ -84,7 +83,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
     @Test
     fun when_in_detail_screen_and_tab_clicked_again_then_it_returns_to_home() = uiTest {
         // Add a task to be able to open it
-        val tasksTitle = runBlocking { getString(HomeDestination.TaskList.title) }
+        val tasksTitle = getString(HomeDestination.TaskList.title)
         val taskName = "Task for navigation"
         onNodeWithContentDescription("Add task").performClick()
         waitUntilExactlyOneExists(hasSetTextAction())
@@ -107,7 +106,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
     fun when_in_search_detail_screen_and_tab_clicked_again_then_it_returns_to_search_home() =
         uiTest {
             // Navigate to Search tab
-            val searchTitle = runBlocking { getString(HomeDestination.Search.title) }
+            val searchTitle = getString(HomeDestination.Search.title)
             onNodeWithContentDescription(label = searchTitle, useUnmergedTree = true).performClick()
 
             // Add a task to be able to search and open it
@@ -145,7 +144,7 @@ internal class HomeScreenTest : AlkaaTest(), KoinTest {
     @Test
     fun when_in_more_detail_screen_and_tab_clicked_again_then_it_returns_to_more_home() = uiTest {
         // Navigate to More tab
-        val moreTitle = runBlocking { getString(HomeDestination.Preferences.title) }
+        val moreTitle = getString(HomeDestination.Preferences.title)
         onNodeWithContentDescription(label = moreTitle, useUnmergedTree = true).performClick()
 
         // Open About screen

--- a/shared/src/commonTest/kotlin/com/escodro/alkaa/TaskFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/escodro/alkaa/TaskFlowTest.kt
@@ -27,7 +27,6 @@ import com.escodro.local.dao.TaskDao
 import com.escodro.task.model.AlarmInterval
 import com.escodro.task.presentation.list.CheckboxNameKey
 import com.escodro.test.AlkaaTest
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.compose.resources.getString
 import org.koin.core.component.inject
@@ -163,7 +162,7 @@ internal class TaskFlowTest : AlkaaTest(), KoinTest {
         onNodeWithText("Confirm").performClick()
 
         // Set repeating randomly
-        val alarmArray = AlarmInterval.entries.map { runBlocking { getString(it.title) } }
+        val alarmArray = AlarmInterval.entries.map { getString(it.title) }
         onNodeWithText(alarmArray[0]).performClick()
         onNodeWithText(alarmArray.last()).performClick()
 

--- a/shared/src/commonTest/kotlin/com/escodro/alkaa/TrackerFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/escodro/alkaa/TrackerFlowTest.kt
@@ -16,7 +16,6 @@ import com.escodro.resources.Res
 import com.escodro.resources.tracker_header_empty
 import com.escodro.task.presentation.list.CheckboxNameKey
 import com.escodro.test.AlkaaTest
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.compose.resources.getString
 import org.koin.test.KoinTest
@@ -47,9 +46,7 @@ internal class TrackerFlowTest : AlkaaTest(), KoinTest {
     fun open_clean_task_tracker_and_ensure_empty_message_is_shown() = uiTest {
         navigateToTracker()
 
-        val emptyMessage = runBlocking {
-            getString(Res.string.tracker_header_empty)
-        }
+        val emptyMessage = getString(Res.string.tracker_header_empty)
         onNodeWithText(text = emptyMessage).assertExists()
     }
 

--- a/shared/src/commonTest/kotlin/com/escodro/alkaa/test/AlkaaTest.kt
+++ b/shared/src/commonTest/kotlin/com/escodro/alkaa/test/AlkaaTest.kt
@@ -47,7 +47,7 @@ fun afterTest() {
  * @param block the test to be executed
  */
 @OptIn(ExperimentalTestApi::class)
-fun uiTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
+fun uiTest(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     setContent {
         CompositionLocalProvider(
             LocalLifecycleOwner provides LocalLifecycleOwnerFake(),
@@ -67,7 +67,7 @@ fun uiTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
 @OptIn(ExperimentalTestApi::class)
 fun flakyUiTest(
     times: Int = 5,
-    block: ComposeUiTest.() -> Unit,
+    block: suspend ComposeUiTest.() -> Unit,
 ) = retry(times) {
     uiTest(block)
 }


### PR DESCRIPTION
Update uiTest and flakyUiTest to accept suspend blocks, allowing direct use of getString(Res.string.xyz) without runBlocking. Update all test files and documentation skills to reflect this cleaner pattern.